### PR TITLE
Fix more warnings found by go vet.

### DIFF
--- a/dgraph/cmd/bulk/mapper.go
+++ b/dgraph/cmd/bulk/mapper.go
@@ -235,7 +235,7 @@ func (m *mapper) lookupUid(xid string) uint64 {
 		// Don't store xids for blank nodes.
 		return uid
 	}
-	nq := gql.NQuad{&api.NQuad{
+	nq := gql.NQuad{NQuad: &api.NQuad{
 		Subject:   xid,
 		Predicate: "xid",
 		ObjectValue: &api.Value{

--- a/dgraph/cmd/server/share.go
+++ b/dgraph/cmd/server/share.go
@@ -34,7 +34,7 @@ import (
 // NewSharedQueryNQuads returns nquads with query and hash.
 func NewSharedQueryNQuads(query []byte) []*api.NQuad {
 	val := func(s string) *api.Value {
-		return &api.Value{Val: &api.Value_DefaultVal{s}}
+		return &api.Value{Val: &api.Value_DefaultVal{DefaultVal: s}}
 	}
 	qHash := fmt.Sprintf("%x", sha256.Sum256(query))
 	return []*api.NQuad{

--- a/dgraph/cmd/zero/oracle.go
+++ b/dgraph/cmd/zero/oracle.go
@@ -368,7 +368,6 @@ func (s *Server) Oracle(unused *api.Payload, server pb.Zero_OracleServer) error 
 			return errServerShutDown
 		}
 	}
-	return nil
 }
 
 func (s *Server) SyncedUntil() uint64 {


### PR DESCRIPTION
These are the go vet warnings that this commit addresses:

    # github.com/dgraph-io/dgraph/dgraph/cmd/zero
    dgraph/cmd/zero/oracle.go:371: unreachable code
    # github.com/dgraph-io/dgraph/dgraph/cmd/bulk
    dgraph/cmd/bulk/mapper.go:238: github.com/dgraph-io/dgraph/gql.NQuad composite literal uses unkeyed fields
    # github.com/dgraph-io/dgraph/dgraph/cmd/server
    dgraph/cmd/server/share.go:37: github.com/dgraph-io/dgo/protos/api.Value_DefaultVal composite literal uses unkeyed fields

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2666)
<!-- Reviewable:end -->
