### PR TITLE
Update k8s config for Dgraph Zero for proper signal handling.

### DIFF
--- a/contrib/config/kubernetes/dgraph-ha/dgraph-ha.yaml
+++ b/contrib/config/kubernetes/dgraph-ha/dgraph-ha.yaml
@@ -165,9 +165,9 @@ spec:
             ordinal=${BASH_REMATCH[1]}
             idx=$(($ordinal + 1))
             if [[ $ordinal -eq 0 ]]; then
-              dgraph zero --my=$(hostname -f):5080 --idx $idx --replicas 3
+              exec dgraph zero --my=$(hostname -f):5080 --idx $idx --replicas 3
             else
-              dgraph zero --my=$(hostname -f):5080 --peer dgraph-zero-0.dgraph-zero.${POD_NAMESPACE}.svc.cluster.local:5080 --idx $idx --replicas 3
+              exec dgraph zero --my=$(hostname -f):5080 --peer dgraph-zero-0.dgraph-zero.${POD_NAMESPACE}.svc.cluster.local:5080 --idx $idx --replicas 3
             fi
       terminationGracePeriodSeconds: 60
       volumes:

--- a/contrib/config/kubernetes/helm/templates/zero-statefulset.yaml
+++ b/contrib/config/kubernetes/helm/templates/zero-statefulset.yaml
@@ -102,9 +102,9 @@ spec:
              ordinal=${BASH_REMATCH[1]}
              idx=$(($ordinal + 1))
              if [[ $ordinal -eq 0 ]]; then
-               dgraph zero --my=$(hostname -f):5080 --idx $idx --replicas {{ .Values.zero.replicaCount }}
+               exec dgraph zero --my=$(hostname -f):5080 --idx $idx --replicas {{ .Values.zero.replicaCount }}
              else
-               dgraph zero --my=$(hostname -f):5080 --peer {{ template "dgraph.zero.fullname" . }}-0.{{ template "dgraph.zero.fullname" . }}-headless.${POD_NAMESPACE}.svc.cluster.local:5080 --idx $idx --replicas {{ .Values.zero.replicaCount }}
+               exec dgraph zero --my=$(hostname -f):5080 --peer {{ template "dgraph.zero.fullname" . }}-0.{{ template "dgraph.zero.fullname" . }}-headless.${POD_NAMESPACE}.svc.cluster.local:5080 --idx $idx --replicas {{ .Values.zero.replicaCount }}
              fi 
         resources:
 {{ toYaml .Values.zero.resources | indent 10 }}


### PR DESCRIPTION
The command for Dgraph Zero runs as `bash` to set the proper hostname and index for each Zero and the proper peer addresses for the Zero peers. This change runs the `dgraph zero` via `exec`, so that the Zero processes properly receive signals such as SIGTERM to terminate cleanly in the event of pod deletion.

To verify the change:

```bash
# from dgraph repo directory
cd ./contrib/config/kubernetes/dgraph-ha.yaml
kubectl apply -f dgraph-ha.yaml
kubectl delete -f dgraph-ha.yaml
# Before this change: The Alpha pods are deleted quickly, but the Zero pods stick around in the Terminating state until the termination grace period kills the Zero pods.
# After this change: # Both the Alpha and Zero pods shutdown gracefully.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3972)
<!-- Reviewable:end -->
