### PR TITLE
doc: remove unnecessary curly braces from doc

### DIFF
--- a/wiki/content/slash-graphql/admin/import-export.md
+++ b/wiki/content/slash-graphql/admin/import-export.md
@@ -16,14 +16,12 @@ Please note that this endpoint requires [Authentication](/slash-graphql/admin/au
 Below is a sample GraphQL body to export data to JSON.
 
 ```graphql
-{
   mutation {
     export {
       response { code message }
       signedUrls
     }
   }
-}
 ```
 
 The `signedUrls` output field contains a list of URLs which can be downloaded. The URLs will expire after 48 hours.

--- a/wiki/content/slash-graphql/admin/import-export.md
+++ b/wiki/content/slash-graphql/admin/import-export.md
@@ -16,12 +16,12 @@ Please note that this endpoint requires [Authentication](/slash-graphql/admin/au
 Below is a sample GraphQL body to export data to JSON.
 
 ```graphql
-  mutation {
-    export {
-      response { code message }
-      signedUrls
-    }
+mutation {
+  export {
+    response { code message }
+    signedUrls
   }
+}
 ```
 
 The `signedUrls` output field contains a list of URLs which can be downloaded. The URLs will expire after 48 hours.


### PR DESCRIPTION
The example provided for exporting data in the Data Export Import page was incorrect. The GraphQL mutation had extra curly braces. This fix removes those curly braces.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6256)
<!-- Reviewable:end -->
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-fd5b392943-87599.surge.sh)
<!-- Dgraph:end -->