### PR TITLE
bug fix to permit audit streaming to stdout writer

### DIFF
--- a/ee/audit/audit_ee.go
+++ b/ee/audit/audit_ee.go
@@ -68,7 +68,10 @@ func GetAuditConf(conf string) *x.LoggerConf {
 		return nil
 	}
 	auditFlag := z.NewSuperFlag(conf).MergeAndCheckDefault(worker.AuditDefaults)
-	out := auditFlag.GetPath("output")
+	out := auditFlag.GetString("output")
+	if out != "stdout" {
+		out = auditFlag.GetPath("output")
+	}
 	x.AssertTruef(out != "", "out flag is not provided for the audit logs")
 	encBytes, err := readAuditEncKey(auditFlag)
 	x.Check(err)


### PR DESCRIPTION
The current code doesn't allow stdout (reserved keyword) to be used for audit streaming (since everything was being resolved as a path).

This PR first checks if the passed value is the same as stdout, if not it resolves it to a path

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7803)
<!-- Reviewable:end -->
