### PR TITLE
fix(live): quote the xid when doing upsert (#7985)

### DIFF
--- a/dgraph/cmd/live/run.go
+++ b/dgraph/cmd/live/run.go
@@ -317,9 +317,9 @@ func generateQuery(node, predicate, xid string) string {
 	sb.WriteString(node)
 	sb.WriteString("(func: eq(")
 	sb.WriteString(predicate)
-	sb.WriteString(`, "`)
-	sb.WriteString(xid)
-	sb.WriteString(`")) {uid}`)
+	sb.WriteString(`, `)
+	sb.WriteString(strconv.Quote(xid))
+	sb.WriteString(`)) {uid}`)
 	return sb.String()
 }
 


### PR DESCRIPTION
(cherry picked from commit 9159e846243cccdc0dd7ac297bc8f2161ed39a5c)

Co-authored-by: NamanJain8 <jnaman806@gmail.com>

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7999)
<!-- Reviewable:end -->
