### PR TITLE
feat(graphql/auth): support "none" algo for JWT verification.

### DIFF
--- a/graphql/authorization/auth.go
+++ b/graphql/authorization/auth.go
@@ -45,6 +45,7 @@ const (
 
 var (
 	supportedAlgorithms = map[string]jwt.SigningMethod{
+		jwt.SigningMethodNone.Alg(): jwt.SigningMethodNone,
 		jwt.SigningMethodRS256.Name: jwt.SigningMethodRS256,
 		jwt.SigningMethodRS384.Name: jwt.SigningMethodRS384,
 		jwt.SigningMethodRS512.Name: jwt.SigningMethodRS512,
@@ -92,7 +93,7 @@ func (a *AuthMeta) validate() error {
 			fields = " `Audience` "
 		}
 	} else {
-		if a.VerificationKey == "" {
+		if a.Algo != "none" && a.VerificationKey == "" {
 			fields = " `Verification key`/`JWKUrl`/`JWKUrls`"
 		}
 
@@ -401,6 +402,10 @@ func (a *AuthMeta) validateJWTCustomClaims(jwtStr string) (*CustomClaims, error)
 				if algo != a.Algo {
 					return nil, errors.Errorf("unexpected signing method: Expected %s Found %s",
 						a.Algo, algo)
+				}
+
+				if a.Algo == "none" {
+					return jwt.UnsafeAllowNoneSignatureType, nil
 				}
 
 				switch a.SigningMethod.(type) {


### PR DESCRIPTION
**Problem**
For development purposes Firebase provides an authentication emulator. This emulator signs JWTs with a "none" algorithm, which is not yet supported in DGraph.

**Solution**
Added the "none" algorithm to the supportedAlgorithms for authorization. When the "none" algorithm is set in the schema, no verification key has to be set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/8073)
<!-- Reviewable:end -->
