### PR TITLE
fix(fragment): merge the nested fragments fields

### DIFF
--- a/graphql/schema/request.go
+++ b/graphql/schema/request.go
@@ -203,6 +203,9 @@ func recursivelyExpandFragmentSelections(field *ast.Field, op *operation) {
 	}, field.SelectionSet, satisfies)
 	field.SelectionSet = make([]ast.Selection, 0, len(collectedFields))
 	for _, collectedField := range collectedFields {
+		if len(collectedField.Selections) > 0 {
+			collectedField.Field.SelectionSet = collectedField.Selections
+		}
 		field.SelectionSet = append(field.SelectionSet, collectedField.Field)
 	}
 


### PR DESCRIPTION
Fixes https://discuss.dgraph.io/t/graphql-field-collection-does-not-work-with-dgraph/15646
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/8075)
<!-- Reviewable:end -->
