### PR TITLE
fix(sort): Only filter out nodes with positive offsets.

### DIFF
--- a/worker/sort.go
+++ b/worker/sort.go
@@ -329,7 +329,7 @@ BUCKETS:
 
 		// Apply the offset on null nodes, if the nodes with value were not enough.
 		if out[i].offset < len(nullNodes) {
-			if out[i].offset > 0 {
+			if out[i].offset >= 0 {
 				nullNodes = nullNodes[out[i].offset:]
 			}
 		} else {


### PR DESCRIPTION
Negative offsets (e.g., `offset: -4`) can cause panics when sorting. This can happen when the query has the following characteristics:

1. The query is sorting on an indexed predicate
2. The results include nodes that also don't have the sorted predicate
3. A negative offset is used.

```
panic: runtime error: slice bounds out of range [-4:]

goroutine 1762633 [running]:
github.com/dgraph-io/dgraph/worker.sortWithIndex(0x1fb12e0, 0xc00906a880, 0xc009068660, 0x0)
        /ext-go/1/src/github.com/dgraph-io/dgraph/worker/sort.go:330 +0x244d
github.com/dgraph-io/dgraph/worker.processSort.func2(0x1fb12e0, 0xc00906a880, 0xc009068660, 0xc0090686c0)
        /ext-go/1/src/github.com/dgraph-io/dgraph/worker/sort.go:515 +0x3f
created by github.com/dgraph-io/dgraph/worker.processSort
        /ext-go/1/src/github.com/dgraph-io/dgraph/worker/sort.go:514 +0x52a
```


<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/8077)
<!-- Reviewable:end -->
