### PR TITLE
fix(query): Do not execute filters if there are no source uids (#7962…

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -230,25 +230,27 @@ type Function struct {
 // SubGraph is the way to represent data. It contains both the request parameters and the response.
 // Once generated, this can then be encoded to other client convenient formats, like GraphQL / JSON.
 // SubGraphs are recursively nested. Each SubGraph contain the following:
-// * SrcUIDS: A list of UIDs that were sent to this query. If this subgraph is a child graph, then the
-//            DestUIDs of the parent must match the SrcUIDs of the children.
-// * DestUIDs: A list of UIDs for which there can be output found in the Children field
-// * Children: A list of child results for this query
-// * valueMatrix: A list of values, against a single attribute, such as name (for a scalar subgraph).
-//                This must be the same length as the SrcUIDs
-// * uidMatrix: A list of outgoing edges. This must be same length as the SrcUIDs list.
+//   - SrcUIDS: A list of UIDs that were sent to this query. If this subgraph is a child graph, then the
+//     DestUIDs of the parent must match the SrcUIDs of the children.
+//   - DestUIDs: A list of UIDs for which there can be output found in the Children field
+//   - Children: A list of child results for this query
+//   - valueMatrix: A list of values, against a single attribute, such as name (for a scalar subgraph).
+//     This must be the same length as the SrcUIDs
+//   - uidMatrix: A list of outgoing edges. This must be same length as the SrcUIDs list.
+//
 // Example, say we are creating a SubGraph for a query "users", which returns one user with name 'Foo', you may get
 // SubGraph
-//   Params: { Alias: "users" }
-//   SrcUIDs: [1]
-//   DestUIDs: [1]
-//   uidMatrix: [[1]]
-//   Children:
-//     SubGraph:
-//       Attr: "name"
-//       SrcUIDs: [1]
-//       uidMatrix: [[]]
-//       valueMatrix: [["Foo"]]
+//
+//	Params: { Alias: "users" }
+//	SrcUIDs: [1]
+//	DestUIDs: [1]
+//	uidMatrix: [[1]]
+//	Children:
+//	  SubGraph:
+//	    Attr: "name"
+//	    SrcUIDs: [1]
+//	    uidMatrix: [[]]
+//	    valueMatrix: [["Foo"]]
 type SubGraph struct {
 	ReadTs      uint64
 	Cache       int
@@ -2210,6 +2212,10 @@ func ProcessGraph(ctx context.Context, sg, parent *SubGraph, rch chan error) {
 			}
 
 			filter.SrcUIDs = sg.DestUIDs
+			if len(filter.SrcUIDs.Uids) == 0 {
+				filterChan <- nil
+				continue
+			}
 			// Passing the pointer is okay since the filter only reads.
 			filter.Params.ParentVars = sg.Params.ParentVars // Pass to the child.
 			go ProcessGraph(ctx, filter, sg, filterChan)

--- a/query/query1_test.go
+++ b/query/query1_test.go
@@ -2377,6 +2377,19 @@ func TestFilterRoot(t *testing.T) {
 	require.JSONEq(t, `{"data": {"me": []}}`, js)
 }
 
+func TestFilterWithNoSrcUid(t *testing.T) {
+
+	query := `{
+		me(func: eq(name, "Does Not Exist")) @filter(eq(name, "Michonne")) {
+			uid
+			name
+		}
+	}
+	`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data": {"me": []}}`, js)
+}
+
 func TestMathAlias(t *testing.T) {
 
 	query := `{


### PR DESCRIPTION
No need to execute filter subgraph if there are no source UIDs.

(cherry picked from commit 849b587e101100059287e15fea0bf0be689904ea)

## Description
The original PR adds a fail fast methodology, where it doesn't expand on a filter subgraph if the srcUid is nil. The current cherry-pick PR brings that change in and adds a test case that scenario.

## Test
`TestFilterWithNoSrcUid`

