### PR TITLE
perf(cache): Add a sharded map for global cache

### DIFF
--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -1417,6 +1417,7 @@ func (s *Server) doQuery(ctx context.Context, req *Request) (resp *api.Response,
 		EncodingNs:        uint64(l.Json.Nanoseconds()),
 		TotalNs:           uint64((time.Since(l.Start)).Nanoseconds()),
 	}
+	//fmt.Println("====Query Resp", qc.req.Query, qc.req.StartTs, qc.req, string(resp.Json))
 	return resp, gqlErrs
 }
 

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/dgraph-io/dgraph/v24
 
 go 1.22.7
 
-replace github.com/dgraph-io/ristretto => /home/harshil/Projects/ristretto/
-
 require (
 	contrib.go.opencensus.io/exporter/jaeger v0.2.1
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2
@@ -17,7 +15,6 @@ require (
 	github.com/dgraph-io/gqlgen v0.13.2
 	github.com/dgraph-io/gqlparser/v2 v2.2.2
 	github.com/dgraph-io/graphql-transport-ws v0.0.0-20210511143556-2cef522f1f15
-	github.com/dgraph-io/ristretto v0.0.0-00010101000000-000000000000
 	github.com/dgraph-io/ristretto/v2 v2.0.0
 	github.com/dgraph-io/simdjson-go v0.3.0
 	github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/dgraph-io/dgraph/v24
 
 go 1.22.7
 
+replace github.com/dgraph-io/ristretto => /home/harshil/Projects/ristretto/
+
 require (
 	contrib.go.opencensus.io/exporter/jaeger v0.2.1
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2
@@ -15,6 +17,7 @@ require (
 	github.com/dgraph-io/gqlgen v0.13.2
 	github.com/dgraph-io/gqlparser/v2 v2.2.2
 	github.com/dgraph-io/graphql-transport-ws v0.0.0-20210511143556-2cef522f1f15
+	github.com/dgraph-io/ristretto v0.0.0-00010101000000-000000000000
 	github.com/dgraph-io/ristretto/v2 v2.0.0
 	github.com/dgraph-io/simdjson-go v0.3.0
 	github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da

--- a/posting/index.go
+++ b/posting/index.go
@@ -218,11 +218,28 @@ func (txn *Txn) addIndexMutation(ctx context.Context, edge *pb.DirectedEdge, tok
 		return err
 	}
 
-	x.AssertTrue(plist != nil)
 	if err = plist.addMutation(ctx, txn, edge); err != nil {
 		return err
 	}
-	ostats.Record(ctx, x.NumEdges.M(1))
+
+	//mpost := NewPosting(edge)
+	//mpost.StartTs = txn.StartTs
+	//if mpost.PostingType != pb.Posting_REF {
+	//	edge.ValueId = fingerprintEdge(edge)
+	//	mpost.Uid = edge.ValueId
+	//}
+
+	////fmt.Println("ADDING MUTATION", plist.mutationMap, key, edge)
+	//txn.addConflictKey(indexConflicKey(key, edge))
+
+	//plist.Lock()
+	//defer plist.Unlock()
+	//if err != plist.updateMutationLayer(mpost, false) {
+	//	return errors.Wrapf(err, "cannot update mutation layer of key %s with value %+v",
+	//		hex.EncodeToString(plist.key), mpost)
+	//}
+
+	//ostats.Record(ctx, x.NumEdges.M(1))
 	return nil
 }
 

--- a/posting/index_test.go
+++ b/posting/index_test.go
@@ -157,6 +157,7 @@ func addMutation(t *testing.T, l *List, edge *pb.DirectedEdge, op uint32,
 	}
 
 	txn.Update()
+	txn.UpdateCachedKeys(commitTs)
 	writer := NewTxnWriter(pstore)
 	require.NoError(t, txn.CommitToDisk(writer, commitTs))
 	require.NoError(t, writer.Flush())

--- a/posting/mvcc_test.go
+++ b/posting/mvcc_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/dgraph-io/dgraph/v24/protos/pb"
 	"github.com/dgraph-io/dgraph/v24/x"
-	"github.com/dgraph-io/ristretto"
+	"github.com/dgraph-io/ristretto/v2"
 	"github.com/dgraph-io/ristretto/v2/z"
 )
 

--- a/posting/mvcc_test.go
+++ b/posting/mvcc_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/dgraph-io/dgraph/v24/protos/pb"
 	"github.com/dgraph-io/dgraph/v24/x"
+	"github.com/dgraph-io/ristretto"
 	"github.com/dgraph-io/ristretto/v2/z"
 )
 
@@ -100,21 +101,23 @@ func TestCacheAfterDeltaUpdateRecieved(t *testing.T) {
 }
 
 func BenchmarkTestCache(b *testing.B) {
-	//lCache, _ = ristretto.NewCache[[]byte, *List](&ristretto.Config[[]byte, *List]{
-	//	// Use 5% of cache memory for storing counters.
-	//	NumCounters: int64(1000 * (1 << 20) * 0.05 * 2),
-	//	MaxCost:     int64(1000 * (1 << 20) * 0.95),
-	//	BufferItems: 64,
-	//	Metrics:     true,
-	//	Cost: func(val *List) int64 {
-	//		return 0
-	//	},
-	//})
+	lCache, _ = ristretto.NewCache[[]byte, *List](&ristretto.Config[[]byte, *List]{
+		// Use 5% of cache memory for storing counters.
+		NumCounters: int64(1000 * (1 << 20) * 0.05 * 2),
+		MaxCost:     int64(1000 * (1 << 20) * 0.95),
+		BufferItems: 64,
+		Metrics:     true,
+		Cost: func(val *List) int64 {
+			return 0
+		},
+	})
 
 	attr := x.GalaxyAttr("cache")
 	keys := make([][]byte, 0)
 	N := 10000
 	txn := Oracle().RegisterStartTs(1)
+
+	memoryLayer.insert = 100000000
 
 	for i := 1; i < N; i++ {
 		key := x.DataKey(attr, uint64(i))

--- a/posting/oracle.go
+++ b/posting/oracle.go
@@ -105,7 +105,7 @@ func (vt *viTxn) GetWithLockHeld(key []byte) (rval index.Value, rerr error) {
 func (vt *viTxn) GetValueFromPostingList(pl *List) (rval index.Value, rerr error) {
 	value := pl.findStaticValue(vt.delegate.StartTs)
 
-	if value == nil {
+	if value == nil || len(value.Postings) == 0 {
 		//fmt.Println("DIFF", val, err, nil, badger.ErrKeyNotFound)
 		return nil, ErrNoValue
 	}

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -359,7 +359,7 @@ func (n *node) applyMutations(ctx context.Context, proposal *pb.Proposal) (rerr 
 
 		// TODO: Revisit this when we work on posting cache. Clear entire cache.
 		// We don't want to drop entire cache, just due to one namespace.
-		// posting.ResetCache()
+		posting.ResetCache()
 		return nil
 	}
 

--- a/worker/online_restore.go
+++ b/worker/online_restore.go
@@ -410,6 +410,7 @@ func handleRestoreProposal(ctx context.Context, req *pb.RestoreRequest, pidx uin
 		return errors.Wrapf(err, "cannot load schema after restore")
 	}
 
+	posting.ResetCache()
 	ResetAclCache()
 
 	// Reset gql schema only when the restore is not partial, so that after this restore

--- a/x/keys.go
+++ b/x/keys.go
@@ -307,7 +307,7 @@ func (p ParsedKey) String() string {
 	} else if p.IsCountOrCountRev() {
 		return fmt.Sprintf("UID: %v, Attr: %v, IsCount/Ref: true, Count: %v", p.Uid, p.Attr, p.Count)
 	} else {
-		return fmt.Sprintf("UID: %v, Attr: %v, Data key", p.Uid, p.Attr)
+		return fmt.Sprintf("UID: %v, Attr: %v, Data key, prefix; %v, byte: %v", p.Uid, p.Attr, p.bytePrefix, p.ByteType)
 	}
 }
 


### PR DESCRIPTION
Main without risteretto cache:
```
badger 2024/10/06 20:34:31 INFO: All 0 tables opened in 0s
badger 2024/10/06 20:34:31 INFO: Discard stats nextEmptySlot: 0
badger 2024/10/06 20:34:31 INFO: Set nextTxnTs to 0
goos: linux
goarch: amd64
pkg: github.com/dgraph-io/dgraph/v24/posting
cpu: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
BenchmarkTestCache-8     1673727               751.5 ns/op
PASS
ok      github.com/dgraph-io/dgraph/v24/posting 2.073s
```

Main with risteretto branch:
```
badger 2024/10/06 20:35:36 INFO: All 0 tables opened in 0s
badger 2024/10/06 20:35:36 INFO: Discard stats nextEmptySlot: 0
badger 2024/10/06 20:35:36 INFO: Set nextTxnTs to 0
goos: linux
goarch: amd64
pkg: github.com/dgraph-io/dgraph/v24/posting
cpu: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
BenchmarkTestCache-8     2333268               501.3 ns/op
PASS
ok      github.com/dgraph-io/dgraph/v24/posting 1.531s
```


This PR:
```
badger 2024/10/06 20:34:12 INFO: All 0 tables opened in 0s
badger 2024/10/06 20:34:12 INFO: Discard stats nextEmptySlot: 0
badger 2024/10/06 20:34:12 INFO: Set nextTxnTs to 0
goos: linux
goarch: amd64
pkg: github.com/dgraph-io/dgraph/v24/posting
cpu: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
BenchmarkTestCache-8     3668409               319.3 ns/op
PASS
ok      github.com/dgraph-io/dgraph/v24/posting 1.576s
```

