### PR TITLE
fix: ensure consistent time units and prevent erroneous cleanup in incrRollupi Process

### DIFF
--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -215,10 +215,10 @@ func (ir *incrRollupi) Process(closer *z.Closer, getNewTs func(bool) uint64) {
 		case <-closer.HasBeenClosed():
 			return
 		case <-cleanupTick.C:
-			currTs := time.Now().UnixNano()
+			currTs := time.Now().Unix()
 			for hash, ts := range m {
 				// Remove entries from map which have been there for there more than 10 seconds.
-				if currTs-ts >= int64(10*time.Second) {
+				if currTs-ts >= 10 {
 					delete(m, hash)
 				}
 			}


### PR DESCRIPTION

**Description**

This PR fixes a bug in the Process function of incrRollupi. The issue was caused by inconsistent time units between the doRollup and cleanupTick logic. Specifically, doRollup used time.Now().Unix() (seconds), while cleanupTick used time.Now().UnixNano() (nanoseconds). This mismatch caused cleanupTick to erroneously delete all entries in the map m during every cleanup cycle.

**Checklist**

- [x] Code compiles correctly and linting passes locally

