### PR TITLE
Use Intersect to Narrow Iterate Range and Reduce Memory Allocation

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -1706,10 +1706,15 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 	}
 
 	if opt.Intersect != nil && len(opt.Intersect.Uids) < l.mutationMap.len()+codec.ApproxLen(l.plist.Pack) {
-		for _, uid := range opt.Intersect.Uids {
-			if uid <= opt.AfterUid {
-				continue
-			}
+		start := 0
+		if opt.AfterUid > 0 {
+			start = sort.Search(len(opt.Intersect.Uids), func(i int) bool {
+				return opt.Intersect.Uids[i] > opt.AfterUid
+			})
+		}
+
+		for i := start; i < len(opt.Intersect.Uids); i++ {
+			uid := opt.Intersect.Uids[i]
 
 			found, _, err := l.findPosting(opt.ReadTs, uid)
 			if err != nil {

--- a/posting/list.go
+++ b/posting/list.go
@@ -1685,7 +1685,11 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 		return out, nil
 	}
 
-	preAllowcateLength := x.MinInt(opt.First, l.mutationMap.len()+codec.ApproxLen(l.plist.Pack))
+	absFirst := opt.First
+	if opt.First < 0 {
+		absFirst = -opt.First
+	}
+	preAllowcateLength := x.MinInt(absFirst, l.mutationMap.len()+codec.ApproxLen(l.plist.Pack))
 	if opt.Intersect != nil {
 		preAllowcateLength = x.MinInt(preAllowcateLength, len(opt.Intersect.Uids))
 	}

--- a/posting/list.go
+++ b/posting/list.go
@@ -1689,9 +1689,9 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 	if opt.First < 0 {
 		absFirst = -opt.First
 	}
-	preAllowcateLength := x.MinInt(absFirst, l.mutationMap.len()+codec.ApproxLen(l.plist.Pack))
+	preAllowcateLength := min(absFirst, l.mutationMap.len()+codec.ApproxLen(l.plist.Pack))
 	if opt.Intersect != nil {
-		preAllowcateLength = x.MinInt(preAllowcateLength, len(opt.Intersect.Uids))
+		preAllowcateLength = min(preAllowcateLength, len(opt.Intersect.Uids))
 	}
 	// Pre-assign length to make it faster.
 	res := make([]uint64, 0, preAllowcateLength)

--- a/posting/list.go
+++ b/posting/list.go
@@ -1690,7 +1690,7 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 		preAllowcateLength = x.MinInt(preAllowcateLength, len(opt.Intersect.Uids))
 	}
 	// Pre-assign length to make it faster.
-	res := make([]uint64, 0, x.MinInt(opt.First, len(opt.Intersect.Uids), l.mutationMap.len()+codec.ApproxLen(l.plist.Pack)))
+	res := make([]uint64, 0, preAllowcateLength)
 
 	checkLimit := func() bool {
 		// We need the last N.

--- a/posting/list.go
+++ b/posting/list.go
@@ -1687,9 +1687,22 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 		return out, nil
 	}
 
+	var uidMin, uidMax uint64 = 0, 0
+	if opt.Intersect != nil && len(opt.Intersect.Uids) > 0 {
+		uidMin = opt.Intersect.Uids[0]
+		uidMax = opt.Intersect.Uids[len(opt.Intersect.Uids)-1]
+	}
+
 	err := l.iterate(opt.ReadTs, opt.AfterUid, func(p *pb.Posting) error {
 		if p.PostingType == pb.Posting_REF {
+			if p.Uid < uidMin {
+				return nil
+			}
+			if p.Uid > uidMax && uidMax > 0 {
+				return ErrStopIteration
+			}
 			res = append(res, p.Uid)
+
 			if opt.First < 0 {
 				// We need the last N.
 				// TODO: This could be optimized by only considering some of the last UidBlocks.

--- a/posting/list.go
+++ b/posting/list.go
@@ -1685,6 +1685,10 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 		return out, nil
 	}
 
+	preAllowcateLength := x.MinInt(opt.First, l.mutationMap.len()+codec.ApproxLen(l.plist.Pack))
+	if opt.Intersect != nil {
+		preAllowcateLength = x.MinInt(preAllowcateLength, len(opt.Intersect.Uids))
+	}
 	// Pre-assign length to make it faster.
 	res := make([]uint64, 0, x.MinInt(opt.First, len(opt.Intersect.Uids), l.mutationMap.len()+codec.ApproxLen(l.plist.Pack)))
 

--- a/posting/list.go
+++ b/posting/list.go
@@ -1707,6 +1707,10 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 
 	if opt.Intersect != nil && len(opt.Intersect.Uids) < l.mutationMap.len()+codec.ApproxLen(l.plist.Pack) {
 		for _, uid := range opt.Intersect.Uids {
+			if uid <= opt.AfterUid {
+				continue
+			}
+
 			found, _, err := l.findPosting(opt.ReadTs, uid)
 			if err != nil {
 				l.RUnlock()

--- a/x/x.go
+++ b/x/x.go
@@ -619,6 +619,38 @@ func Max(a, b uint64) uint64 {
 	return b
 }
 
+// MinInt returns the smallest integer among the given numbers.
+// The first two arguments are mandatory, additional numbers are optional.
+func MinInt(a, b int, nums ...int) int {
+	min := a
+	if b < min {
+		min = b
+	}
+
+	for _, num := range nums {
+		if num < min {
+			min = num
+		}
+	}
+	return min
+}
+
+// MaxInt returns the largest integer among the given numbers.
+// The first two arguments are mandatory, additional numbers are optional.
+func MaxInt(a, b int, nums ...int) int {
+	max := a
+	if b > max {
+		max = b
+	}
+
+	for _, num := range nums {
+		if num > max {
+			max = num
+		}
+	}
+	return max
+}
+
 // ExponentialRetry runs the given function until it succeeds or can no longer be retried.
 func ExponentialRetry(maxRetries int, waitAfterFailure time.Duration,
 	f func() error) error {

--- a/x/x.go
+++ b/x/x.go
@@ -619,38 +619,6 @@ func Max(a, b uint64) uint64 {
 	return b
 }
 
-// MinInt returns the smallest integer among the given numbers.
-// The first two arguments are mandatory, additional numbers are optional.
-func MinInt(a, b int, nums ...int) int {
-	min := a
-	if b < min {
-		min = b
-	}
-
-	for _, num := range nums {
-		if num < min {
-			min = num
-		}
-	}
-	return min
-}
-
-// MaxInt returns the largest integer among the given numbers.
-// The first two arguments are mandatory, additional numbers are optional.
-func MaxInt(a, b int, nums ...int) int {
-	max := a
-	if b > max {
-		max = b
-	}
-
-	for _, num := range nums {
-		if num > max {
-			max = num
-		}
-	}
-	return max
-}
-
 // ExponentialRetry runs the given function until it succeeds or can no longer be retried.
 func ExponentialRetry(maxRetries int, waitAfterFailure time.Duration,
 	f func() error) error {


### PR DESCRIPTION
**Description**

In our index data, some hot keys are associated with a large number of UIDs, but the set filtered by our function is relatively small. During performance testing on this dataset, I noticed that pl.Uids consumes a significant amount of CPU time for slice memory allocation. Therefore, I propose an optimization in the Uids function to leverage the range provided by Intersect to reduce the scope of temporary result sets, thereby minimizing memory allocation.