### PR TITLE
perf(core): Use Intersect to Narrow Iterate Range and Reduce Memory Allocation in pl.Uids()

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -1718,20 +1718,6 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 		res := make([]uint64, 0, l.ApproxLen())
 		out := &pb.List{}
 
-		if opt.Intersect != nil && len(opt.Intersect.Uids) < l.ApproxLen() {
-			for _, uid := range opt.Intersect.Uids {
-				ok, _, err := l.findPosting(uid, opt.ReadTs)
-				if err != nil {
-					return nil, err, false
-				}
-				if ok {
-					res = append(res, uid)
-				}
-			}
-			out.Uids = res
-			return out, nil, false
-		}
-
 		if l.mutationMap.len() == 0 && opt.Intersect != nil && len(l.plist.Splits) == 0 {
 			if opt.ReadTs < l.minTs {
 				return out, errors.Wrapf(ErrTsTooOld, "While reading UIDs"), false
@@ -1739,6 +1725,20 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 			algo.IntersectCompressedWith(l.plist.Pack, opt.AfterUid, opt.Intersect, out)
 			return out, nil, false
 		}
+
+		//if opt.Intersect != nil && len(opt.Intersect.Uids) < l.ApproxLen() {
+		//	for _, uid := range opt.Intersect.Uids {
+		//		ok, _, err := l.findPosting(uid, opt.ReadTs)
+		//		if err != nil {
+		//			return nil, err, false
+		//		}
+		//		if ok {
+		//			res = append(res, uid)
+		//		}
+		//	}
+		//	out.Uids = res
+		//	return out, nil, false
+		//}
 
 		var uidMin, uidMax uint64 = 0, 0
 		if opt.Intersect != nil && len(opt.Intersect.Uids) > 0 {

--- a/posting/list.go
+++ b/posting/list.go
@@ -1715,13 +1715,15 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 	res := make([]uint64, 0, l.ApproxLen())
 	out := &pb.List{}
 
-	if opt.Intersect != nil && len(opt.Intersect) < l.ApproxLen() {
-		for _, uid := range opt.Intersect {
+	if opt.Intersect != nil && len(opt.Intersect.Uids) < l.ApproxLen() {
+		for _, uid := range opt.Intersect.Uids {
 			ok, _, err := l.findPosting(uid, opt.ReadTs)
 			if err != nil {
 				return nil, err
 			}
-			res = append(res, p.Uid)
+			if ok {
+				res = append(res, uid)
+			}
 		}
 		out.Uids = res
 		return out, nil

--- a/posting/list.go
+++ b/posting/list.go
@@ -1726,19 +1726,19 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 			return out, nil, false
 		}
 
-		//if opt.Intersect != nil && len(opt.Intersect.Uids) < l.ApproxLen() {
-		//	for _, uid := range opt.Intersect.Uids {
-		//		ok, _, err := l.findPosting(uid, opt.ReadTs)
-		//		if err != nil {
-		//			return nil, err, false
-		//		}
-		//		if ok {
-		//			res = append(res, uid)
-		//		}
-		//	}
-		//	out.Uids = res
-		//	return out, nil, false
-		//}
+		if opt.Intersect != nil && len(opt.Intersect.Uids) < l.ApproxLen() {
+			for _, uid := range opt.Intersect.Uids {
+				ok, _, err := l.findPosting(uid, opt.ReadTs)
+				if err != nil {
+					return nil, err, false
+				}
+				if ok {
+					res = append(res, uid)
+				}
+			}
+			out.Uids = res
+			return out, nil, false
+		}
 
 		var uidMin, uidMax uint64 = 0, 0
 		if opt.Intersect != nil && len(opt.Intersect.Uids) > 0 {

--- a/posting/list.go
+++ b/posting/list.go
@@ -1778,6 +1778,10 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 				hex.EncodeToString(l.key)), false
 		}
 		if ranIterate {
+			if opt.Intersect != nil {
+				out.Uids = res
+				algo.IntersectWith(out, opt.Intersect, out)
+			}
 			if len(res) != len(resFromIterate) {
 				fmt.Println(l.key, l.print(), res, resFromIterate)
 				panic("hi")

--- a/posting/list.go
+++ b/posting/list.go
@@ -1716,6 +1716,7 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 		defer l.RUnlock()
 		// Use approximate length for initial capacity.
 		res := make([]uint64, 0, l.ApproxLen())
+		resFromIterate := make([]uint64, 0)
 		out := &pb.List{}
 
 		if l.mutationMap.len() == 0 && opt.Intersect != nil && len(l.plist.Splits) == 0 {
@@ -1734,10 +1735,12 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 				}
 				if ok {
 					res = append(res, uid)
+					resFromIterate = append(resFromIterate, uid)
 				}
 			}
-			out.Uids = res
-			return out, nil, false
+
+			//out.Uids = res
+			//return out, nil, false
 		}
 
 		var uidMin, uidMax uint64 = 0, 0
@@ -1771,6 +1774,20 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 		if err != nil {
 			return out, errors.Wrapf(err, "cannot retrieve UIDs from list with key %s",
 				hex.EncodeToString(l.key)), false
+		}
+		if len(resFromIterate) > 0 {
+			if len(res) != len(resFromIterate) {
+				fmt.Println(l.key, l.Print(), res, resFromIterate)
+				panic("hi")
+			}
+			if len(res) == len(resFromIterate) {
+				for i := range res {
+					if res[i] != resFromIterate[i] {
+						fmt.Println(l.key, l.Print(), res, resFromIterate)
+						panic("hi")
+					}
+				}
+			}
 		}
 		out.Uids = res
 		return out, nil, true

--- a/posting/list.go
+++ b/posting/list.go
@@ -1726,7 +1726,10 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 			return out, nil, false
 		}
 
+		// If we need to intersect and the number of elements are small, in that case it's better to
+		// just check each item is present or not.
 		if opt.Intersect != nil && len(opt.Intersect.Uids) < l.ApproxLen() {
+			// Cache the iterator as it makes the search space smaller each time.
 			var pitr pIterator
 			for _, uid := range opt.Intersect.Uids {
 				ok, _, err := l.findPostingWithItr(opt.ReadTs, uid, pitr)
@@ -1742,6 +1745,8 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 			return out, nil, false
 		}
 
+		// If we are going to iterate over the list, in that case we only need to read between min and max
+		// of opt.Intersect.
 		var uidMin, uidMax uint64 = 0, 0
 		if opt.Intersect != nil && len(opt.Intersect.Uids) > 0 {
 			uidMin = opt.Intersect.Uids[0]

--- a/posting/list.go
+++ b/posting/list.go
@@ -1734,7 +1734,7 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 
 		if l.mutationMap.len() == 0 && opt.Intersect != nil && len(l.plist.Splits) == 0 {
 			if opt.ReadTs < l.minTs {
-				return out, errors.Wrapf(ErrTsTooOld, "While reading UIDs")
+				return out, errors.Wrapf(ErrTsTooOld, "While reading UIDs"), false
 			}
 			algo.IntersectCompressedWith(l.plist.Pack, opt.AfterUid, opt.Intersect, out)
 			return out, nil, false
@@ -1782,7 +1782,7 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 		return out, err
 	}
 
-	lenBefore := len(res)
+	lenBefore := len(out.Uids)
 	if opt.Intersect != nil {
 		algo.IntersectWith(out, opt.Intersect, out)
 	}

--- a/posting/list.go
+++ b/posting/list.go
@@ -1728,7 +1728,7 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 
 		if opt.Intersect != nil && len(opt.Intersect.Uids) < l.ApproxLen() {
 			for _, uid := range opt.Intersect.Uids {
-				ok, _, err := l.findPosting(uid, opt.ReadTs)
+				ok, _, err := l.findPosting(opt.ReadTs, uid)
 				if err != nil {
 					return nil, err, false
 				}

--- a/posting/list.go
+++ b/posting/list.go
@@ -1716,8 +1716,6 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 		defer l.RUnlock()
 		// Use approximate length for initial capacity.
 		res := make([]uint64, 0, l.ApproxLen())
-		ranIterate := false
-		resFromIterate := make([]uint64, 0)
 		out := &pb.List{}
 
 		if l.mutationMap.len() == 0 && opt.Intersect != nil && len(l.plist.Splits) == 0 {
@@ -1729,7 +1727,6 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 		}
 
 		if opt.Intersect != nil && len(opt.Intersect.Uids) < l.ApproxLen() {
-			ranIterate = true
 			for _, uid := range opt.Intersect.Uids {
 				ok, _, err := l.findPosting(uid, opt.ReadTs)
 				if err != nil {
@@ -1737,12 +1734,11 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 				}
 				if ok {
 					res = append(res, uid)
-					resFromIterate = append(resFromIterate, uid)
 				}
 			}
 
-			//out.Uids = res
-			//return out, nil, false
+			out.Uids = res
+			return out, nil, false
 		}
 
 		var uidMin, uidMax uint64 = 0, 0
@@ -1776,24 +1772,6 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 		if err != nil {
 			return out, errors.Wrapf(err, "cannot retrieve UIDs from list with key %s",
 				hex.EncodeToString(l.key)), false
-		}
-		if ranIterate {
-			if opt.Intersect != nil {
-				out.Uids = res
-				algo.IntersectWith(out, opt.Intersect, out)
-			}
-			if len(res) != len(resFromIterate) {
-				fmt.Println(l.key, l.print(), res, resFromIterate)
-				panic("hi")
-			}
-			if len(res) == len(resFromIterate) {
-				for i := range res {
-					if res[i] != resFromIterate[i] {
-						fmt.Println(l.key, l.print(), res, resFromIterate)
-						panic("hi")
-					}
-				}
-			}
 		}
 		out.Uids = res
 		return out, nil, true

--- a/posting/list.go
+++ b/posting/list.go
@@ -1716,6 +1716,7 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 		defer l.RUnlock()
 		// Use approximate length for initial capacity.
 		res := make([]uint64, 0, l.ApproxLen())
+		ranIterate := false
 		resFromIterate := make([]uint64, 0)
 		out := &pb.List{}
 
@@ -1728,6 +1729,7 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 		}
 
 		if opt.Intersect != nil && len(opt.Intersect.Uids) < l.ApproxLen() {
+			ranIterate = true
 			for _, uid := range opt.Intersect.Uids {
 				ok, _, err := l.findPosting(uid, opt.ReadTs)
 				if err != nil {
@@ -1775,15 +1777,17 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 			return out, errors.Wrapf(err, "cannot retrieve UIDs from list with key %s",
 				hex.EncodeToString(l.key)), false
 		}
-		if len(res) != len(resFromIterate) {
-			fmt.Println(l.key, l.print(), res, resFromIterate)
-			panic("hi")
-		}
-		if len(res) == len(resFromIterate) {
-			for i := range res {
-				if res[i] != resFromIterate[i] {
-					fmt.Println(l.key, l.print(), res, resFromIterate)
-					panic("hi")
+		if ranIterate {
+			if len(res) != len(resFromIterate) {
+				fmt.Println(l.key, l.print(), res, resFromIterate)
+				panic("hi")
+			}
+			if len(res) == len(resFromIterate) {
+				for i := range res {
+					if res[i] != resFromIterate[i] {
+						fmt.Println(l.key, l.print(), res, resFromIterate)
+						panic("hi")
+					}
 				}
 			}
 		}

--- a/posting/list.go
+++ b/posting/list.go
@@ -1776,13 +1776,13 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 				hex.EncodeToString(l.key)), false
 		}
 		if len(res) != len(resFromIterate) {
-			fmt.Println(l.key, l.Print(), res, resFromIterate)
+			fmt.Println(l.key, l.print(), res, resFromIterate)
 			panic("hi")
 		}
 		if len(res) == len(resFromIterate) {
 			for i := range res {
 				if res[i] != resFromIterate[i] {
-					fmt.Println(l.key, l.Print(), res, resFromIterate)
+					fmt.Println(l.key, l.print(), res, resFromIterate)
 					panic("hi")
 				}
 			}

--- a/posting/list.go
+++ b/posting/list.go
@@ -1709,72 +1709,79 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 	if opt.First == 0 {
 		opt.First = math.MaxInt32
 	}
-	// Pre-assign length to make it faster.
-	l.RLock()
-	// Use approximate length for initial capacity.
-	res := make([]uint64, 0, l.ApproxLen())
-	out := &pb.List{}
 
-	if opt.Intersect != nil && len(opt.Intersect.Uids) < l.ApproxLen() {
-		for _, uid := range opt.Intersect.Uids {
-			ok, _, err := l.findPosting(uid, opt.ReadTs)
-			if err != nil {
-				return nil, err
+	getUidList := func() (*pb.List, error, bool) {
+		// Pre-assign length to make it faster.
+		l.RLock()
+		defer l.RUnlock()
+		// Use approximate length for initial capacity.
+		res := make([]uint64, 0, l.ApproxLen())
+		out := &pb.List{}
+
+		if opt.Intersect != nil && len(opt.Intersect.Uids) < l.ApproxLen() {
+			for _, uid := range opt.Intersect.Uids {
+				ok, _, err := l.findPosting(uid, opt.ReadTs)
+				if err != nil {
+					return nil, err, false
+				}
+				if ok {
+					res = append(res, uid)
+				}
 			}
-			if ok {
-				res = append(res, uid)
+			out.Uids = res
+			return out, nil, false
+		}
+
+		if l.mutationMap.len() == 0 && opt.Intersect != nil && len(l.plist.Splits) == 0 {
+			if opt.ReadTs < l.minTs {
+				return out, errors.Wrapf(ErrTsTooOld, "While reading UIDs")
 			}
+			algo.IntersectCompressedWith(l.plist.Pack, opt.AfterUid, opt.Intersect, out)
+			return out, nil, false
+		}
+
+		var uidMin, uidMax uint64 = 0, 0
+		if opt.Intersect != nil && len(opt.Intersect.Uids) > 0 {
+			uidMin = opt.Intersect.Uids[0]
+			uidMax = opt.Intersect.Uids[len(opt.Intersect.Uids)-1]
+		}
+
+		err := l.iterate(opt.ReadTs, opt.AfterUid, func(p *pb.Posting) error {
+			if p.PostingType == pb.Posting_REF {
+				if p.Uid < uidMin {
+					return nil
+				}
+				if p.Uid > uidMax && uidMax > 0 {
+					return ErrStopIteration
+				}
+				res = append(res, p.Uid)
+
+				if opt.First < 0 {
+					// We need the last N.
+					// TODO: This could be optimized by only considering some of the last UidBlocks.
+					if len(res) > -opt.First {
+						res = res[1:]
+					}
+				} else if len(res) > opt.First {
+					return ErrStopIteration
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return out, errors.Wrapf(err, "cannot retrieve UIDs from list with key %s",
+				hex.EncodeToString(l.key)), false
 		}
 		out.Uids = res
-		return out, nil
-	}
-
-	if l.mutationMap.len() == 0 && opt.Intersect != nil && len(l.plist.Splits) == 0 {
-		if opt.ReadTs < l.minTs {
-			l.RUnlock()
-			return out, errors.Wrapf(ErrTsTooOld, "While reading UIDs")
-		}
-		algo.IntersectCompressedWith(l.plist.Pack, opt.AfterUid, opt.Intersect, out)
-		l.RUnlock()
-		return out, nil
-	}
-
-	var uidMin, uidMax uint64 = 0, 0
-	if opt.Intersect != nil && len(opt.Intersect.Uids) > 0 {
-		uidMin = opt.Intersect.Uids[0]
-		uidMax = opt.Intersect.Uids[len(opt.Intersect.Uids)-1]
-	}
-
-	err := l.iterate(opt.ReadTs, opt.AfterUid, func(p *pb.Posting) error {
-		if p.PostingType == pb.Posting_REF {
-			if p.Uid < uidMin {
-				return nil
-			}
-			if p.Uid > uidMax && uidMax > 0 {
-				return ErrStopIteration
-			}
-			res = append(res, p.Uid)
-
-			if opt.First < 0 {
-				// We need the last N.
-				// TODO: This could be optimized by only considering some of the last UidBlocks.
-				if len(res) > -opt.First {
-					res = res[1:]
-				}
-			} else if len(res) > opt.First {
-				return ErrStopIteration
-			}
-		}
-		return nil
-	})
-	l.RUnlock()
-	if err != nil {
-		return out, errors.Wrapf(err, "cannot retrieve UIDs from list with key %s",
-			hex.EncodeToString(l.key))
+		return out, nil, true
 	}
 
 	// Do The intersection here as it's optimized.
-	out.Uids = res
+	out, err, applyIntersectWith := getUidList()
+	if err != nil || !applyIntersectWith {
+		return out, err
+	}
+
 	lenBefore := len(res)
 	if opt.Intersect != nil {
 		algo.IntersectWith(out, opt.Intersect, out)

--- a/posting/list.go
+++ b/posting/list.go
@@ -1775,17 +1775,15 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 			return out, errors.Wrapf(err, "cannot retrieve UIDs from list with key %s",
 				hex.EncodeToString(l.key)), false
 		}
-		if len(resFromIterate) > 0 {
-			if len(res) != len(resFromIterate) {
-				fmt.Println(l.key, l.Print(), res, resFromIterate)
-				panic("hi")
-			}
-			if len(res) == len(resFromIterate) {
-				for i := range res {
-					if res[i] != resFromIterate[i] {
-						fmt.Println(l.key, l.Print(), res, resFromIterate)
-						panic("hi")
-					}
+		if len(res) != len(resFromIterate) {
+			fmt.Println(l.key, l.Print(), res, resFromIterate)
+			panic("hi")
+		}
+		if len(res) == len(resFromIterate) {
+			for i := range res {
+				if res[i] != resFromIterate[i] {
+					fmt.Println(l.key, l.Print(), res, resFromIterate)
+					panic("hi")
 				}
 			}
 		}


### PR DESCRIPTION
Based off of: #9271 