### PR TITLE
bump Ubuntu to v24.04

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -4,7 +4,7 @@
 # This gets built as part of release.sh. Must be run from /tmp/build, with the linux binaries
 # already built and placed there.
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 LABEL maintainer="Hypermode Inc. <hello@hypermode.com>"
 
 # need to remove the cache of sources lists


### PR DESCRIPTION
**Description**

We've been testing against Ubuntu v24.04, but still building images against v22.04. Bumping to align.

**Checklist**

- [X] Code compiles correctly and linting passes locally