### PR TITLE
chore: bump Go patch version

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -14,7 +14,7 @@ plugins:
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
   enabled:
-    - go@1.22.7
+    - go@1.22.11
     - node@18.20.5
     - python@3.10.8
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@
   available through your OS package manager)
 - Install [Docker](https://docs.docker.com/install/) and
   [Docker Compose](https://docs.docker.com/compose/install/).
-- [Install Go 1.22.7 or above](https://golang.org/doc/install).
+- [Install Go 1.22.11 or above](https://golang.org/doc/install).
 
 ### Setup Dgraph from source repo
 
@@ -111,7 +111,7 @@ Dgraph SHA-256   : 9ce738cd055dfebdef5d68b2a49ea4e062e597799498607dbd1bb618d4886
 Commit SHA-1     : 15839b156
 Commit timestamp : 2025-01-10 17:56:49 -0500
 Branch           : username/some-branch-that-im-on
-Go version       : go1.22.7
+Go version       : go1.22.11
 jemalloc enabled : true
 
 For Dgraph official documentation, visit https://dgraph.io/docs.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hypermodeinc/dgraph/v24
 
-go 1.22.7
+go 1.22.11
 
 require (
 	contrib.go.opencensus.io/exporter/jaeger v0.2.1

--- a/graphql/e2e/custom_logic/cmd/go.mod
+++ b/graphql/e2e/custom_logic/cmd/go.mod
@@ -1,6 +1,6 @@
 module github.com/hypermodeinc/dgraph/graphql/e2e/custom_logic/cmd
 
-go 1.22.7
+go 1.22.11
 
 require (
 	github.com/graph-gophers/graphql-go v1.5.0

--- a/t/Makefile
+++ b/t/Makefile
@@ -6,7 +6,7 @@
 # linux || darwin
 GOOS          ?= $(shell go env GOOS)
 GOPATH        ?= $(shell go env GOPATH)
-MIN_GO_VERSION = "1.22.7"
+MIN_GO_VERSION = "1.22.11"
 
 all: test
 

--- a/t/README.md
+++ b/t/README.md
@@ -16,7 +16,7 @@ dependencies by running `make check`.
 
 ### Go
 
-Version 1.22.7 or higher.
+Version 1.22.11 or higher.
 
 ### Docker
 


### PR DESCRIPTION
**Description**

Bump Go patch version to 1.22.11 to resolve framework dependency vulnerabilities.

**Checklist**

- [X] Code compiles correctly and linting passes locally