### PR TITLE
fix(core): fix unmarshal protobuf when len val is 0 (#9347)

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -616,8 +616,9 @@ func loadFromDB(ctx context.Context, loadType int) error {
 			err := item.Value(func(val []byte) error {
 				if len(val) == 0 {
 					s = pb.SchemaUpdate{Predicate: pk.Attr, ValueType: pb.Posting_DEFAULT}
+				} else {
+					x.Checkf(proto.Unmarshal(val, &s), "Error while loading schema from db")
 				}
-				x.Checkf(proto.Unmarshal(val, &s), "Error while loading schema from db")
 				State().Set(pk.Attr, &s)
 				return nil
 			})
@@ -627,8 +628,9 @@ func loadFromDB(ctx context.Context, loadType int) error {
 			err := item.Value(func(val []byte) error {
 				if len(val) == 0 {
 					t = pb.TypeUpdate{TypeName: pk.Attr}
+				} else {
+					x.Checkf(proto.Unmarshal(val, &t), "Error while loading types from db")
 				}
-				x.Checkf(proto.Unmarshal(val, &t), "Error while loading types from db")
 				State().SetType(pk.Attr, &t)
 				return nil
 			})

--- a/worker/sort_test.go
+++ b/worker/sort_test.go
@@ -66,6 +66,41 @@ func writePostingListToDisk(kvs []*bpb.KV) error {
 	return writer.Flush()
 }
 
+func TestEmptyTypeSchema(t *testing.T) {
+	dir, err := os.MkdirTemp("", "storetest_")
+	x.Check(err)
+	defer os.RemoveAll(dir)
+
+	opt := badger.DefaultOptions(dir)
+	ps, err := badger.OpenManaged(opt)
+	x.Check(err)
+	pstore = ps
+	posting.Init(ps, 0, false)
+	Init(ps)
+
+	typeName := "1-temp"
+	ts := uint64(10)
+	txn := pstore.NewTransactionAt(ts, true)
+	defer txn.Discard()
+	e := &badger.Entry{
+		Key:      x.TypeKey(typeName),
+		Value:    make([]byte, 0),
+		UserMeta: posting.BitSchemaPosting,
+	}
+	require.Nil(t, txn.SetEntry(e.WithDiscard()))
+	require.Nil(t, txn.CommitAt(ts, nil))
+
+	schema.Init(ps)
+	require.Nil(t, schema.LoadFromDb(context.Background()))
+
+	req := &pb.SchemaRequest{}
+	types, err := GetTypes(context.Background(), req)
+	require.Nil(t, err)
+
+	require.Equal(t, 1, len(types))
+	x.ParseNamespaceAttr(types[0].TypeName)
+}
+
 func TestMultipleTxnListCount(t *testing.T) {
 	dir, err := os.MkdirTemp("", "storetest_")
 	x.Check(err)


### PR DESCRIPTION
**Description**

Please explain the changes you made here.

**Checklist**

- [ ] Code compiles correctly and linting passes locally
- [ ] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to
      this PR
- [ ] Tests added for new functionality, or regression tests for bug fixes added as applicable
- [ ] For public APIs, new features, etc., PR on
      [docs repo](https://github.com/dgraph-io/dgraph-docs) staged and linked here

**Instructions**

- The PR title should follow the [Conventional Commits](https://www.conventionalcommits.org/)
  syntax, leading with `fix:`, `feat:`, `chore:`, `ci:`, etc.
- The description should briefly explain what the PR is about. In the case of a bugfix, describe or
  link to the bug.
- In the checklist section, check the boxes in that are applicable, using `[x]` syntax.
  - If not applicable, remove the entire line. Only leave the box unchecked if you intend to come
    back and check the box later.
- Delete the `Instructions` line and everything below it, to indicate you have read and are
  following these instructions. 🙂

Thank you for your contribution to Dgraph!
