### PR TITLE
undo the breaking change made while removing sentry flag

### DIFF
--- a/dgraph/docker-compose.yml
+++ b/dgraph/docker-compose.yml
@@ -15,9 +15,9 @@ services:
         target: /gobin
         read_only: true
     command:
-      /gobin/dgraph  ${COVERAGE_OUTPUT} zero --telemetry "reports=false;" --my=zero1:5080 --replicas
-      3 --raft="idx=1" --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate
-      10
+      /gobin/dgraph  ${COVERAGE_OUTPUT} zero --telemetry "reports=false; sentry=false;"
+      --my=zero1:5080 --replicas 3 --raft="idx=1" --logtostderr -v=2 --bindall --expose_trace
+      --profile_mode block --block_rate 10
 
   zero2:
     image: dgraph/dgraph:local

--- a/x/flags.go
+++ b/x/flags.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	TraceDefaults     = `ratio=0.01; jaeger=; datadog=;`
-	TelemetryDefaults = `reports=true;`
+	TelemetryDefaults = `reports=true;sentry=false;`
 )
 
 // FillCommonFlags stores flags common to Alpha and Zero.


### PR DESCRIPTION
Affected versions: v24.1.1
we require a default for each flag and we removed the default value for sentry flag from the code.