### PR TITLE
fix(core): delete existing plists when doing a single UID update

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -773,7 +773,12 @@ func (l *List) updateMutationLayer(mpost *pb.Posting, singleUidUpdate, hasCountI
 		// Add the deletions in the existing plist because those postings are not picked
 		// up by iterating. Not doing so would result in delete operations that are not
 		// applied when the transaction is committed.
-		l.mutationMap.currentEntries = &pb.PostingList{}
+		for _, post := range l.mutationMap.currentEntries.Postings {
+			if post.Op == Del && post.Uid != mpost.Uid {
+				newPlist.Postings = append(newPlist.Postings, post)
+			}
+		}
+
 		err := l.iterate(mpost.StartTs, 0, func(obj *pb.Posting) error {
 			// Ignore values which have the same uid as they will get replaced
 			// by the current value.


### PR DESCRIPTION
If a single UID predicate (not a list) is updated, the old value is not deleted. This bug was introduced in https://github.com/hypermodeinc/dgraph/pull/9292. 

This PR adds the old behavior back.

Related: https://discuss.hypermode.com/t/inconsistent-query-result/19844/7

Note: I don't know why this was changed in the original PR as the existing comment in the code says that the loop is necessary, so please review carefully. 