### PR TITLE
fix(core): use passed context when joining cluster

### DIFF
--- a/conn/node.go
+++ b/conn/node.go
@@ -771,7 +771,7 @@ func (n *Node) joinCluster(ctx context.Context, rc *pb.RaftContext) (*api.Payloa
 	}
 	n.Connect(rc.Id, rc.Addr)
 
-	err := n.addToCluster(context.Background(), rc)
+	err := n.addToCluster(ctx, rc)
 	glog.Infof("[%#x] Done joining cluster with err: %v", rc.Id, err)
 	return &api.Payload{}, err
 }


### PR DESCRIPTION
This PR addresses an issue where the function does not propagate the passed context, resulting in the creation of a new context (`context.Background`). As a result, context timeouts and cancellations do not work. This update ensures proper context handling.