### PR TITLE
Add implementation for AllocateIDs and use the API in live loader

### DIFF
--- a/dgraph/cmd/live/batch.go
+++ b/dgraph/cmd/live/batch.go
@@ -19,7 +19,6 @@ import (
 	"github.com/dgryski/go-farm"
 	"github.com/dustin/go-humanize"
 	"github.com/dustin/go-humanize/english"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -78,7 +77,6 @@ type loader struct {
 	uidsLock  sync.RWMutex
 
 	reqs       chan *request
-	zeroconn   *grpc.ClientConn
 	schema     *Schema
 	namespaces map[uint64]struct{}
 

--- a/dgraph/cmd/live/load-json/load_test.go
+++ b/dgraph/cmd/live/load-json/load_test.go
@@ -23,7 +23,6 @@ import (
 )
 
 var alphaService = testutil.SockAddr
-var zeroService = testutil.SockAddrZero
 
 var (
 	testDataDir string
@@ -91,8 +90,7 @@ func TestLiveLoadJSONFileEmpty(t *testing.T) {
 		{"echo", "[]"},
 		{testutil.DgraphBinaryPath(), "live",
 			"--schema", testDataDir + "/family.schema", "--files", "/dev/stdin",
-			"--alpha", alphaService, "--zero", zeroService,
-			"--creds", "user=groot;password=password;"},
+			"--alpha", alphaService, "--creds", "user=groot;password=password;"},
 	}
 	_, err := testutil.Pipeline(pipeline)
 	require.NoError(t, err, "live loading JSON file ran successfully")
@@ -104,8 +102,7 @@ func TestLiveLoadJSONFile(t *testing.T) {
 	pipeline := [][]string{
 		{testutil.DgraphBinaryPath(), "live",
 			"--schema", testDataDir + "/family.schema", "--files", testDataDir + "/family.json",
-			"--alpha", alphaService, "--zero", zeroService,
-			"--creds", "user=groot;password=password;"},
+			"--alpha", alphaService, "--creds", "user=groot;password=password;"},
 	}
 	_, err := testutil.Pipeline(pipeline)
 	require.NoError(t, err, "live loading JSON file exited with error")
@@ -119,8 +116,7 @@ func TestLiveLoadCanUseAlphaForAssigningUids(t *testing.T) {
 	pipeline := [][]string{
 		{testutil.DgraphBinaryPath(), "live",
 			"--schema", testDataDir + "/family.schema", "--files", testDataDir + "/family.json",
-			"--alpha", alphaService, "--zero", alphaService,
-			"--creds", "user=groot;password=password;"},
+			"--alpha", alphaService, "--creds", "user=groot;password=password;"},
 	}
 	_, err := testutil.Pipeline(pipeline)
 	require.NoError(t, err, "live loading JSON file exited with error")
@@ -135,8 +131,7 @@ func TestLiveLoadJSONCompressedStream(t *testing.T) {
 		{"gzip", "-c", testDataDir + "/family.json"},
 		{testutil.DgraphBinaryPath(), "live",
 			"--schema", testDataDir + "/family.schema", "--files", "/dev/stdin",
-			"--alpha", alphaService, "--zero", zeroService,
-			"--creds", "user=groot;password=password;"},
+			"--alpha", alphaService, "--creds", "user=groot;password=password;"},
 	}
 	_, err := testutil.Pipeline(pipeline)
 	require.NoError(t, err, "live loading JSON stream exited with error")
@@ -157,8 +152,7 @@ func TestLiveLoadJSONMultipleFiles(t *testing.T) {
 	pipeline := [][]string{
 		{testutil.DgraphBinaryPath(), "live",
 			"--schema", testDataDir + "/family.schema", "--files", fileList,
-			"--alpha", alphaService, "--zero", zeroService,
-			"--creds", "user=groot;password=password;"},
+			"--alpha", alphaService, "--creds", "user=groot;password=password;"},
 	}
 	_, err := testutil.Pipeline(pipeline)
 	require.NoError(t, err, "live loading multiple JSON files exited with error")

--- a/dgraph/cmd/live/load-uids/load_test.go
+++ b/dgraph/cmd/live/load-uids/load_test.go
@@ -35,7 +35,6 @@ var (
 
 var (
 	alphaService    string
-	zeroService     string
 	alphaName       string
 	alphaExportPath string
 	localExportPath = "./export_copy"
@@ -87,8 +86,7 @@ func TestLiveLoadUpsertAtOnce(t *testing.T) {
 	pipeline := [][]string{
 		{testutil.DgraphBinaryPath(), "live",
 			"--schema", testDataDir + "/xid.schema", "--files", file, "--alpha",
-			alphaService, "--zero", zeroService,
-			"--creds", "user=groot;password=password;", "-U", "xid"},
+			alphaService, "--creds", "user=groot;password=password;", "-U", "xid"},
 	}
 	_, err := testutil.Pipeline(pipeline)
 	require.NoError(t, err, "live loading JSON file exited with error")
@@ -102,8 +100,7 @@ func TestLiveLoadUpsert(t *testing.T) {
 	pipeline := [][]string{
 		{testutil.DgraphBinaryPath(), "live",
 			"--schema", testDataDir + "/xid.schema", "--files", testDataDir + "/xid_a.rdf",
-			"--alpha", alphaService, "--zero", zeroService,
-			"--creds", "user=groot;password=password;", "-U", "xid"},
+			"--alpha", alphaService, "--creds", "user=groot;password=password;", "-U", "xid"},
 	}
 	_, err := testutil.Pipeline(pipeline)
 	require.NoError(t, err, "live loading JSON file exited with error")
@@ -111,8 +108,7 @@ func TestLiveLoadUpsert(t *testing.T) {
 	pipeline = [][]string{
 		{testutil.DgraphBinaryPath(), "live",
 			"--schema", testDataDir + "/xid.schema", "--files", testDataDir + "/xid_b.rdf",
-			"--alpha", alphaService, "--zero", zeroService,
-			"--creds", "user=groot;password=password;", "-U", "xid"},
+			"--alpha", alphaService, "--creds", "user=groot;password=password;", "-U", "xid"},
 	}
 	_, err = testutil.Pipeline(pipeline)
 	require.NoError(t, err, "live loading JSON file exited with error")
@@ -190,8 +186,7 @@ func TestLiveLoadJsonUidKeep(t *testing.T) {
 	pipeline := [][]string{
 		{testutil.DgraphBinaryPath(), "live",
 			"--schema", testDataDir + "/family.schema", "--files", testDataDir + "/family.json",
-			"--alpha", alphaService, "--zero", zeroService,
-			"--creds", "user=groot;password=password;"},
+			"--alpha", alphaService, "--creds", "user=groot;password=password;"},
 	}
 	_, err := testutil.Pipeline(pipeline)
 	require.NoError(t, err, "live loading JSON file exited with error")
@@ -205,8 +200,7 @@ func TestLiveLoadJsonUidDiscard(t *testing.T) {
 	pipeline := [][]string{
 		{testutil.DgraphBinaryPath(), "live", "--new_uids",
 			"--schema", testDataDir + "/family.schema", "--files", testDataDir + "/family.json",
-			"--alpha", alphaService, "--zero", zeroService,
-			"--creds", "user=groot;password=password;"},
+			"--alpha", alphaService, "--creds", "user=groot;password=password;"},
 	}
 	_, err := testutil.Pipeline(pipeline)
 	require.NoError(t, err, "live loading JSON file exited with error")
@@ -220,8 +214,7 @@ func TestLiveLoadRdfUidKeep(t *testing.T) {
 	pipeline := [][]string{
 		{testutil.DgraphBinaryPath(), "live",
 			"--schema", testDataDir + "/family.schema", "--files", testDataDir + "/family.rdf",
-			"--alpha", alphaService, "--zero", zeroService,
-			"--creds", "user=groot;password=password;"},
+			"--alpha", alphaService, "--creds", "user=groot;password=password;"},
 	}
 	_, err := testutil.Pipeline(pipeline)
 	require.NoError(t, err, "live loading JSON file exited with error")
@@ -235,8 +228,7 @@ func TestLiveLoadRdfUidDiscard(t *testing.T) {
 	pipeline := [][]string{
 		{testutil.DgraphBinaryPath(), "live", "--new_uids",
 			"--schema", testDataDir + "/family.schema", "--files", testDataDir + "/family.rdf",
-			"--alpha", alphaService, "--zero", zeroService,
-			"--creds", "user=groot;password=password;"},
+			"--alpha", alphaService, "--creds", "user=groot;password=password;"},
 	}
 	_, err := testutil.Pipeline(pipeline)
 	require.NoError(t, err, "live loading JSON file exited with error")
@@ -276,8 +268,7 @@ func TestLiveLoadExportedSchema(t *testing.T) {
 			"--files", localExportPath + "/" + exportId + "/" + groupId + ".rdf.gz",
 			"--encryption",
 			x.BuildEncFlag(testDataDir + "/../../../../enc/test-fixtures/enc-key"),
-			"--alpha", alphaService, "--zero", zeroService,
-			"--creds", "user=groot;password=password;"},
+			"--alpha", alphaService, "--creds", "user=groot;password=password;"},
 	}
 	_, err := testutil.Pipeline(pipeline)
 	require.NoError(t, err, "live loading exported schema exited with error")
@@ -316,8 +307,7 @@ func TestLiveLoadFileName(t *testing.T) {
 	pipeline := [][]string{
 		{testutil.DgraphBinaryPath(), "live",
 			"--files", testDataDir + "/correct1.rdf," + testDataDir + "/errored1.rdf",
-			"--alpha", alphaService, "--zero", zeroService,
-			"--creds", "user=groot;password=password;"},
+			"--alpha", alphaService, "--creds", "user=groot;password=password;"},
 	}
 
 	out, err := testutil.Pipeline(pipeline)
@@ -333,8 +323,7 @@ func TestLiveLoadFileNameMultipleErrored(t *testing.T) {
 	pipeline := [][]string{
 		{testutil.DgraphBinaryPath(), "live",
 			"--files", testDataDir + "/correct1.rdf," + testDataDir + "/errored1.rdf," +
-				testDataDir + "/errored2.rdf", "--alpha", alphaService, "--zero", zeroService,
-			"--creds", "user=groot;password=password;"},
+				testDataDir + "/errored2.rdf", "--alpha", alphaService, "--creds", "user=groot;password=password;"},
 	}
 
 	out, err := testutil.Pipeline(pipeline)
@@ -351,8 +340,7 @@ func TestLiveLoadFileNameMultipleCorrect(t *testing.T) {
 	pipeline := [][]string{
 		{testutil.DgraphBinaryPath(), "live",
 			"--files", testDataDir + "/correct1.rdf," + testDataDir + "/correct2.rdf," +
-				testDataDir + "/errored1.rdf", "--alpha", alphaService, "--zero", zeroService,
-			"--creds", "user=groot;password=password;"},
+				testDataDir + "/errored1.rdf", "--alpha", alphaService, "--creds", "user=groot;password=password;"},
 	}
 
 	out, err := testutil.Pipeline(pipeline)
@@ -365,7 +353,6 @@ func TestLiveLoadFileNameMultipleCorrect(t *testing.T) {
 func TestMain(m *testing.M) {
 	alphaName = testutil.Instance
 	alphaService = testutil.SockAddr
-	zeroService = testutil.SockAddrZero
 
 	x.AssertTrue(strings.Count(alphaName, "_") == 2)
 	left := strings.Index(alphaName, "_")

--- a/edgraph/zero.go
+++ b/edgraph/zero.go
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: © Hypermode Inc. <hello@hypermode.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package edgraph
+
+import (
+	"context"
+	"fmt"
+
+	apiv25 "github.com/dgraph-io/dgo/v250/protos/api.v25"
+	"github.com/hypermodeinc/dgraph/v25/protos/pb"
+	"github.com/hypermodeinc/dgraph/v25/worker"
+
+	"github.com/pkg/errors"
+	"google.golang.org/grpc/status"
+)
+
+func (s *ServerV25) AllocateIDs(ctx context.Context, req *apiv25.AllocateIDsRequest) (
+	*apiv25.AllocateIDsResponse, error) {
+
+	// For now, we only allow users in superadmin group to do this operation in v25
+	if err := AuthSuperAdmin(ctx); err != nil {
+		s := status.Convert(err)
+		return nil, status.Error(s.Code(),
+			"v25.AllocateIDs can only be called by the superadmin group. "+s.Message())
+	}
+
+	num := &pb.Num{Val: req.HowMany}
+	switch req.LeaseType {
+	case apiv25.LeaseType_NS:
+		num.Type = pb.Num_NS_ID
+	case apiv25.LeaseType_UID:
+		num.Type = pb.Num_UID
+	case apiv25.LeaseType_TS:
+		num.Type = pb.Num_TXN_TS
+	default:
+		return nil, fmt.Errorf("invalid lease type: %v", req.LeaseType)
+	}
+
+	resp, err := worker.AssignUidsOverNetwork(ctx, num)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to allocate IDs")
+	}
+
+	return &apiv25.AllocateIDsResponse{Start: resp.StartId, End: resp.EndId}, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/blevesearch/bleve/v2 v2.5.0
 	github.com/dgraph-io/badger/v4 v4.7.0
-	github.com/dgraph-io/dgo/v250 v250.0.0-20250511125955-0567006c46cc
+	github.com/dgraph-io/dgo/v250 v250.0.0-preview1.0.20250511125955-0567006c46cc
 	github.com/dgraph-io/gqlgen v0.13.2
 	github.com/dgraph-io/gqlparser/v2 v2.2.2
 	github.com/dgraph-io/graphql-transport-ws v0.0.0-20210511143556-2cef522f1f15

--- a/go.sum
+++ b/go.sum
@@ -122,8 +122,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgraph-io/badger/v4 v4.7.0 h1:Q+J8HApYAY7UMpL8d9owqiB+odzEc0zn/aqOD9jhc6Y=
 github.com/dgraph-io/badger/v4 v4.7.0/go.mod h1:He7TzG3YBy3j4f5baj5B7Zl2XyfNe5bl4Udl0aPemVA=
-github.com/dgraph-io/dgo/v250 v250.0.0-20250511125955-0567006c46cc h1:TACB/WzfNGQxgxWQelzg6ur/NWoxOmeesrjJwVZ+Zjk=
-github.com/dgraph-io/dgo/v250 v250.0.0-20250511125955-0567006c46cc/go.mod h1:m5zwXW3OyxYK4asn97VxPRcQBn+dYj0uzT2MIu2R4is=
+github.com/dgraph-io/dgo/v250 v250.0.0-preview1.0.20250511125955-0567006c46cc h1:C/eY/o4LQk/uqBNCPVySH/HmGc1uBl4YJYBe8FPjKgo=
+github.com/dgraph-io/dgo/v250 v250.0.0-preview1.0.20250511125955-0567006c46cc/go.mod h1:m5zwXW3OyxYK4asn97VxPRcQBn+dYj0uzT2MIu2R4is=
 github.com/dgraph-io/gqlgen v0.13.2 h1:TNhndk+eHKj5qE7BenKKSYdSIdOGhLqxR1rCiMso9KM=
 github.com/dgraph-io/gqlgen v0.13.2/go.mod h1:iCOrOv9lngN7KAo+jMgvUPVDlYHdf7qDwsTkQby2Sis=
 github.com/dgraph-io/gqlparser/v2 v2.1.1/go.mod h1:MYS4jppjyx8b9tuUtjV7jU1UFZK6P9fvO8TsIsQtRKU=

--- a/query/normalize_feature_flag_test.go
+++ b/query/normalize_feature_flag_test.go
@@ -8,6 +8,7 @@
 package query
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -27,7 +28,9 @@ func TestNormalizeDirectiveWithNoListResponse(t *testing.T) {
 	gc, cleanup, err := c.Client()
 	require.NoError(t, err)
 	defer cleanup()
-	require.NoError(t, c.AssignUids(gc.Dgraph, 100))
+
+	_, _, err = gc.AllocateUIDs(context.Background(), 100)
+	require.NoError(t, err)
 
 	const dataSchema = `
         friend : [uid] @reverse @count .

--- a/systest/21million/live/run_test.go
+++ b/systest/21million/live/run_test.go
@@ -25,7 +25,6 @@ func TestMain(m *testing.M) {
 	rdfFile := filepath.Join(testutil.TestDataDirectory, "21million.rdf.gz")
 	if err := testutil.LiveLoad(testutil.LiveOpts{
 		Alpha:      testutil.ContainerAddr("alpha1", 9080),
-		Zero:       testutil.SockAddrZero,
 		RdfFile:    rdfFile,
 		SchemaFile: schemaFile,
 	}); err != nil {

--- a/systest/bgindex/count_test.go
+++ b/systest/bgindex/count_test.go
@@ -51,7 +51,7 @@ func TestCountIndex(t *testing.T) {
 		t.Fatalf("error in setting up schema :: %v\n", err)
 	}
 
-	if err := testutil.AssignUids(uint64(total * 10)); err != nil {
+	if _, _, err := dg.AllocateUIDs(context.Background(), uint64(total*10)); err != nil {
 		t.Fatalf("error in assigning UIDs :: %v", err)
 	}
 

--- a/systest/bgindex/parallel_test.go
+++ b/systest/bgindex/parallel_test.go
@@ -53,10 +53,6 @@ func addBankData(dg *dgo.Dgraph, pred string) error {
 }
 
 func TestParallelIndexing(t *testing.T) {
-	if err := testutil.AssignUids(uint64(total * 10)); err != nil {
-		t.Fatalf("error in assignig UIDs :: %v", err)
-	}
-
 	var dg *dgo.Dgraph
 	err := x.RetryUntilSuccess(10, time.Second, func() error {
 		var err error
@@ -64,6 +60,10 @@ func TestParallelIndexing(t *testing.T) {
 		return err
 	})
 	require.NoError(t, err)
+
+	if _, _, err := dg.AllocateUIDs(context.Background(), uint64(total*10)); err != nil {
+		t.Fatalf("error in assignig UIDs :: %v", err)
+	}
 
 	testutil.DropAll(t, dg)
 	if err := dg.Alter(context.Background(), &api.Operation{

--- a/systest/bgindex/reverse_test.go
+++ b/systest/bgindex/reverse_test.go
@@ -46,7 +46,7 @@ func TestReverseIndex(t *testing.T) {
 		t.Fatalf("error in setting up schema :: %v\n", err)
 	}
 
-	if err := testutil.AssignUids(uint64(total * 10)); err != nil {
+	if _, _, err := dg.AllocateUIDs(context.Background(), uint64(total*10)); err != nil {
 		t.Fatalf("error in assigning UIDs :: %v", err)
 	}
 

--- a/systest/bgindex/string_test.go
+++ b/systest/bgindex/string_test.go
@@ -51,8 +51,8 @@ func TestStringIndex(t *testing.T) {
 		t.Fatalf("error in setting up schema :: %v\n", err)
 	}
 
-	if err := testutil.AssignUids(uint64(total * 10)); err != nil {
-		t.Fatalf("error in assignig UIDs :: %v", err)
+	if _, _, err := dg.AllocateUIDs(context.Background(), uint64(total*10)); err != nil {
+		t.Fatalf("error in assigning UIDs :: %v", err)
 	}
 
 	// first insert bank accounts

--- a/systest/bulk_live/common/bulk_live_fixture.go
+++ b/systest/bulk_live/common/bulk_live_fixture.go
@@ -145,7 +145,6 @@ func (s *bsuite) setup(t *testing.T, schemaFile, rdfFile, gqlSchemaFile string) 
 	}
 
 	err := testutil.LiveLoad(testutil.LiveOpts{
-		Zero:       testutil.ContainerAddr("zero1", 5080),
 		Alpha:      testutil.ContainerAddr("alpha1", 9080),
 		RdfFile:    rdfFile,
 		SchemaFile: schemaFile,

--- a/systest/integration2/incremental_restore_test.go
+++ b/systest/integration2/incremental_restore_test.go
@@ -42,7 +42,8 @@ func TestIncrementalRestore(t *testing.T) {
 		dgraphapi.DefaultPassword, x.RootNamespace))
 
 	uids := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
-	c.AssignUids(gc.Dgraph, uint64(len(uids)))
+	_, _, err = gc.AllocateUIDs(context.Background(), uint64(len(uids)))
+	require.NoError(t, err)
 	require.NoError(t, gc.SetupSchema(`money: [int] @index(int) @count .`))
 
 	for i := 1; i <= len(uids); i++ {

--- a/systest/multi-tenancy/integration_basic_helper_test.go
+++ b/systest/multi-tenancy/integration_basic_helper_test.go
@@ -41,7 +41,6 @@ func (msuite *MultitenancyTestSuite) liveLoadData(opts *liveOpts) error {
 	require.NoError(t, os.WriteFile(gqlSchemaFile, []byte(opts.gqlSchema), 0644))
 	// Load the data.
 	return testutil.LiveLoad(testutil.LiveOpts{
-		Zero:       testutil.ContainerAddr("zero1", 5080),
 		Alpha:      testutil.ContainerAddr("alpha1", 9080),
 		RdfFile:    rdfFile,
 		SchemaFile: schemaFile,
@@ -194,7 +193,12 @@ func (msuite *MultitenancyTestSuite) TestLiveLoadMulti() {
 			_:b <name> "ns gary" <%#x> .
 			_:c <name> "ns hola" <%#x> .`, ns, 0x100),
 		schema: `name: string @index(term) .`,
-		creds:  &testutil.LoginParams{UserID: dgraphapi.DefaultUser, Passwd: dgraphapi.DefaultPassword, Namespace: ns},
+		creds: &testutil.LoginParams{
+			UserID:    dgraphapi.DefaultUser,
+			Passwd:    dgraphapi.DefaultPassword,
+			Namespace: x.RootNamespace,
+		},
+		forceNs: int64(ns),
 	}))
 
 	resp, err = gcli1.Query(query3)

--- a/testutil/bulk.go
+++ b/testutil/bulk.go
@@ -22,7 +22,6 @@ import (
 
 type LiveOpts struct {
 	Alpha      string
-	Zero       string
 	RdfFile    string
 	SchemaFile string
 	Dir        string
@@ -42,7 +41,6 @@ func LiveLoad(opts LiveOpts) error {
 		"--files", opts.RdfFile,
 		"--schema", opts.SchemaFile,
 		"--alpha", opts.Alpha,
-		"--zero", opts.Zero,
 	}
 	if opts.Creds != nil {
 		if opts.Creds.Namespace == x.RootNamespace || opts.ForceNs != 0 {
@@ -63,8 +61,10 @@ func LiveLoad(opts LiveOpts) error {
 
 	out, err := liveCmd.CombinedOutput()
 	if err != nil {
+		fmt.Println("================================================================")
 		fmt.Printf("Error %v\n", err)
 		fmt.Printf("Output %v\n", string(out))
+		fmt.Println("================================================================")
 		return errors.Wrap(err, string(out))
 	}
 	if CheckIfRace(out) {

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -609,7 +609,7 @@ func AssignNsIdsOverNetwork(ctx context.Context, num *pb.Num) (*pb.AssignedIds, 
 	return c.AssignIds(ctx, num)
 }
 
-// AssignUidsOverNetwork sends a request to assign UIDs to blank nodes to the current zero leader.
+// AssignUidsOverNetwork sends a request to assign UIDs from the current zero leader.
 func AssignUidsOverNetwork(ctx context.Context, num *pb.Num) (*pb.AssignedIds, error) {
 	// Pass on the incoming metadata to the zero. Namespace from the metadata is required by zero.
 	if md, ok := metadata.FromIncomingContext(ctx); ok {

--- a/worker/upgrade_test.go
+++ b/worker/upgrade_test.go
@@ -52,10 +52,17 @@ func setSchema(schema string) {
 
 func populateCluster(t *testing.T, dc dgraphapi.Cluster) {
 	x.Panic(client.Alter(context.Background(), &api.Operation{DropAll: true}))
-	x.Panic(dc.AssignUids(client.Dgraph, 65536))
+
+	isHigher, err := dgraphtest.IsHigherVersion(dc.GetVersion(), "e648e774befe03ca2e602b192b4c888cddba6b89")
+	x.Panic(err)
+	if isHigher {
+		_, _, err := client.AllocateUIDs(context.Background(), 65536)
+		x.Panic(err)
+	} else {
+		x.Panic(dc.AssignUids(client.Dgraph, 65536))
+	}
 
 	setSchema(schemaIndexed)
-
 	require.NoError(t, delClusterEdge(t, fmt.Sprintf("<%#x> <friend> <%#x> .", 1, 2)))
 }
 


### PR DESCRIPTION
This PR implements the AllocateIDs API for allocating UIDs, namespaces and timestamps for bulk and live loader. For now, this PR also updates the live loader to use this API and completely avoid talking to zero directly.