### PR TITLE
fix(core): fix reverse edge loss when set and delete occur together

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -372,7 +372,7 @@ func (mm *MutableLayer) insertPosting(mpost *pb.Posting, hasCountIndex bool) {
 				}
 				res := mm.currentEntries.Postings[:postIndex]
 				if postIndex+1 <= len(mm.currentEntries.Postings) {
-					mm.currentEntries.Postings = append(res,
+					res = append(res,
 						mm.currentEntries.Postings[(postIndex+1):]...)
 				}
 				mm.currentUids = nil

--- a/worker/mutation_unit_test.go
+++ b/worker/mutation_unit_test.go
@@ -55,7 +55,7 @@ func TestReverseEdge(t *testing.T) {
 	pl.RLock()
 	c := pl.GetLength(5)
 	pl.RUnlock()
-	require.Equal(t, c, 0)
+	require.Equal(t, 0, c)
 }
 
 func TestReverseEdgeSetDel(t *testing.T) {

--- a/worker/mutation_unit_test.go
+++ b/worker/mutation_unit_test.go
@@ -58,6 +58,68 @@ func TestReverseEdge(t *testing.T) {
 	require.Equal(t, c, 0)
 }
 
+func TestReverseEdgeSetDel(t *testing.T) {
+	dir, err := os.MkdirTemp("", "storetest_")
+	x.Check(err)
+	defer os.RemoveAll(dir)
+
+	opt := badger.DefaultOptions(dir)
+	ps, err := badger.OpenManaged(opt)
+	x.Check(err)
+	pstore = ps
+	// Not using posting list cache
+	posting.Init(ps, 0, false)
+	Init(ps)
+	err = schema.ParseBytes([]byte("revc: [uid] @reverse @count ."), 1)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	txn := posting.Oracle().RegisterStartTs(5)
+	attr := x.AttrInRootNamespace("revc")
+
+	edgeDel := &pb.DirectedEdge{
+		ValueId: 2,
+		Attr:    attr,
+		Entity:  3,
+		Op:      pb.DirectedEdge_DEL,
+	}
+
+	edgeSet1 := &pb.DirectedEdge{
+		ValueId: 2,
+		Attr:    attr,
+		Entity:  1,
+		Op:      pb.DirectedEdge_SET,
+	}
+	
+	edgeSet2 := &pb.DirectedEdge{
+		ValueId: 2,
+		Attr:    attr,
+		Entity:  3,
+		Op:      pb.DirectedEdge_SET,
+	}
+
+	
+	edgeSet3 := &pb.DirectedEdge{
+		ValueId: 2,
+		Attr:    attr,
+		Entity:  4,
+		Op:      pb.DirectedEdge_SET,
+	}
+
+
+	x.Check(runMutation(ctx, edgeSet1, txn))
+	x.Check(runMutation(ctx, edgeSet2, txn))
+	x.Check(runMutation(ctx, edgeSet3, txn))
+	x.Check(runMutation(ctx, edgeDel, txn))
+
+	pl, err := txn.Get(x.ReverseKey(attr, 2))
+	require.NoError(t, err)
+	pl.RLock()
+	c := pl.GetLength(5)
+	pl.RUnlock()
+	require.Equal(t, 2, c)
+}
+
 func TestConvertEdgeType(t *testing.T) {
 	var testEdges = []struct {
 		input     *pb.DirectedEdge


### PR DESCRIPTION
This PR fixes a bug where a reverse edge (`@reverse` predicate) with a count index (`@count`) may lose values when the same predicate is set and deleted multiple times within a single DQL mutation.
