### PR TITLE
refactor: use slices.Equal to simplify code

### DIFF
--- a/tok/hnsw/persistent_hnsw_test.go
+++ b/tok/hnsw/persistent_hnsw_test.go
@@ -8,6 +8,7 @@ package hnsw
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 	"testing"
 
@@ -341,7 +342,7 @@ func TestFlatEntryInsertToPersistentFlatStorage(t *testing.T) {
 		skey := string(key[:])
 		index.BytesAsFloatArray(tsDbs[0].inMemTestDb[skey], &float1, 64)
 		index.BytesAsFloatArray(tsDbs[99].inMemTestDb[skey], &float2, 64)
-		if !equalFloat64Slice(float1, float2) {
+		if !slices.Equal(float1, float2) {
 			t.Errorf("Vector value for predicate %q at beginning and end of database were "+
 				"not equivalent. Start Value: %v\n, End Value: %v\n %v\n %v", flatPh.pred, tsDbs[0].inMemTestDb[skey],
 				tsDbs[99].inMemTestDb[skey], float1, float2)
@@ -351,7 +352,7 @@ func TestFlatEntryInsertToPersistentFlatStorage(t *testing.T) {
 			edgeName := edge.Attr + "_" + fmt.Sprint(edge.Entity)
 			edgesNameList = append(edgesNameList, edgeName)
 		}
-		if !equalStringSlice(edgesNameList, test.expectedEdgesList) {
+		if !slices.Equal(edgesNameList, test.expectedEdgesList) {
 			t.Errorf("Edges created during insert is incorrect. Expected: %v, Got: %v", test.expectedEdgesList, edgesNameList)
 		}
 		entryKey := DataKey(ConcatStrings(flatPh.pred, VecEntry), 1)
@@ -437,7 +438,7 @@ func TestNonflatEntryInsertToPersistentFlatStorage(t *testing.T) {
 		var float1, float2 = []float64{}, []float64{}
 		index.BytesAsFloatArray(tsDbs[0].inMemTestDb[string(key[:])], &float1, 64)
 		index.BytesAsFloatArray(tsDbs[99].inMemTestDb[string(key[:])], &float2, 64)
-		if !equalFloat64Slice(float1, float2) {
+		if !slices.Equal(float1, float2) {
 			t.Errorf("Vector value for predicate %q at beginning and end of database were "+
 				"not equivalent. Start Value: %v, End Value: %v", flatPh.pred, tsDbs[0].inMemTestDb[flatPh.pred],
 				tsDbs[99].inMemTestDb[flatPh.pred])
@@ -531,7 +532,7 @@ func RunFlatSearchTests(t *testing.T, test searchPersistentFlatStorageTest, flat
 			t.Errorf("Output %q not equal to expected %q", err, test.expectedErr)
 		}
 	}
-	if !equalUint64Slice(nns, test.expectedNns) {
+	if !slices.Equal(nns, test.expectedNns) {
 		t.Errorf("Nearest neighbors expected value: %v, Got: %v", test.expectedNns, nns)
 	}
 }

--- a/tok/hnsw/test_helper.go
+++ b/tok/hnsw/test_helper.go
@@ -232,41 +232,6 @@ func (c *inMemLocalCache) GetWithLockHeld(key []byte) (rval []byte, rerr error) 
 	return val, nil
 }
 
-func equalFloat64Slice(a, b []float64) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}
-
-func equalStringSlice(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}
-
-func equalUint64Slice(a, b []uint64) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}
 
 // floatArrayAsBytes(v) will create a byte array encoding
 // v using LittleEndian format. This is sort of the inverse


### PR DESCRIPTION
**Description**

In the Go 1.21 standard library, a new function has been introduced that enhances code conciseness and readability. It can be find  [here](https://pkg.go.dev/slices@go1.21.1#Equal).

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [ ] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to
      this PR
- [ ] Tests added for new functionality, or regression tests for bug fixes added as applicable
- [ ] For public APIs, new features, etc., PR on
      [docs repo](https://github.com/hypermodeinc/docs) staged and linked here

**Instructions**

- The PR title should follow the [Conventional Commits](https://www.conventionalcommits.org/)
  syntax, leading with `fix:`, `feat:`, `chore:`, `ci:`, etc.
- The description should briefly explain what the PR is about. In the case of a bugfix, describe or
  link to the bug.
- In the checklist section, check the boxes in that are applicable, using `[x]` syntax.
  - If not applicable, remove the entire line. Only leave the box unchecked if you intend to come
    back and check the box later.
- Delete the `Instructions` line and everything below it, to indicate you have read and are
  following these instructions. 🙂

Thank you for your contribution to Dgraph!
