### PR TITLE
fix(core): add map locking and ensure resource cleanup

### DIFF
--- a/dgraph/cmd/root.go
+++ b/dgraph/cmd/root.go
@@ -150,6 +150,7 @@ func initCmds() {
 			if err != nil {
 				x.Fatalf("unable to open config file for reading: %v", err)
 			}
+			defer cfgFile.Close()
 			cfgData, err := io.ReadAll(cfgFile)
 			if err != nil {
 				x.Fatalf("unable to read config file: %v", err)

--- a/posting/list.go
+++ b/posting/list.go
@@ -2242,6 +2242,7 @@ func (l *List) readListPart(startUid uint64) (*pb.PostingList, error) {
 			hex.EncodeToString(l.key), startUid)
 	}
 	txn := pstore.NewTransactionAt(l.minTs, false)
+	defer txn.Discard()
 	item, err := txn.Get(key)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not read list part with key %s",

--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -554,7 +554,9 @@ func NewCachePL() *CachePL {
 }
 
 func checkForRollup(key []byte, l *List) {
+	l.RLock()
 	deltaCount := l.mutationMap.len()
+	l.RUnlock()
 	// If deltaCount is high, send it to high priority channel instead.
 	if deltaCount > 500 {
 		IncrRollup.addKeyToBatch(key, 0)

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -95,6 +95,7 @@ func (s *state) Delete(attr string, ts uint64) error {
 
 	glog.Infof("Deleting schema for predicate: [%s]", attr)
 	txn := pstore.NewTransactionAt(ts, true)
+	defer txn.Discard()
 	if err := txn.Delete(x.SchemaKey(attr)); err != nil {
 		return err
 	}
@@ -119,6 +120,7 @@ func (s *state) DeleteType(typeName string, ts uint64) error {
 
 	glog.Infof("Deleting type definition for type: [%s]", typeName)
 	txn := pstore.NewTransactionAt(ts, true)
+	defer txn.Discard()
 	if err := txn.Delete(x.TypeKey(typeName)); err != nil {
 		return err
 	}
@@ -530,7 +532,7 @@ func Load(predicate string) error {
 	if len(predicate) == 0 {
 		return errors.Errorf("Empty predicate")
 	}
-	delete(State().mutSchema, predicate)
+	State().DeleteMutSchema(predicate)
 	key := x.SchemaKey(predicate)
 	txn := pstore.NewTransactionAt(math.MaxUint64, false)
 	defer txn.Discard()


### PR DESCRIPTION
**Description**

This PR addresses several stability issues:

- Added read/write locks for concurrent access to maps to prevent race conditions.
- Ensured transactions created via `NewTransactionAt` are explicitly discarded to free `readTs` usage.
- Ensured file handles are explicitly closed after use to prevent file descriptor leaks.

These changes improve thread safety, avoid stale transactions blocking version GC, and prevent potential resource exhaustion.


**Checklist**

- [x] Code compiles correctly and linting passes locally
- [ ] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to
      this PR
- [ ] Tests added for new functionality, or regression tests for bug fixes added as applicable
