### PR TITLE
chore(test): Increase performance of t-harness tests

### DIFF
--- a/.github/workflows/ci-dgraph-core-tests.yml
+++ b/.github/workflows/ci-dgraph-core-tests.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   dgraph-core-tests:
     if: github.event.pull_request.draft == false
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: warp-ubuntu-latest-x64-16x
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5

--- a/acl/acl_curl_test.go
+++ b/acl/acl_curl_test.go
@@ -49,7 +49,7 @@ func (asuite *AclTestSuite) TestCurlAuthorization() {
 		return []string{"-H", fmt.Sprintf("X-Dgraph-AccessToken:%s", jwt),
 			"--ipv4",
 			"-H", "Content-Type: application/dql",
-			"-d", query, testutil.SockAddrHttp + "/query"}
+			"-d", query, testutil.GetSockAddrHttp() + "/query"}
 	}
 	testutil.VerifyCurlCmd(t, queryArgs(hc.AccessJwt), &testutil.CurlFailureConfig{
 		ShouldFail: false,
@@ -60,7 +60,7 @@ func (asuite *AclTestSuite) TestCurlAuthorization() {
 			"-H", "Content-Type: application/rdf",
 			"-d", fmt.Sprintf(`{ set {
 	   _:a <%s>  "string" .
-	   }}`, predicateToWrite), testutil.SockAddrHttp + "/mutate"}
+	   }}`, predicateToWrite), testutil.GetSockAddrHttp() + "/mutate"}
 
 	}
 
@@ -71,7 +71,7 @@ func (asuite *AclTestSuite) TestCurlAuthorization() {
 
 	alterArgs := func(jwt string) []string {
 		return []string{"-H", fmt.Sprintf("X-Dgraph-AccessToken:%s", jwt),
-			"-d", fmt.Sprintf(`%s: int .`, predicateToAlter), testutil.SockAddrHttp + "/alter"}
+			"-d", fmt.Sprintf(`%s: int .`, predicateToAlter), testutil.GetSockAddrHttp() + "/alter"}
 	}
 	testutil.VerifyCurlCmd(t, alterArgs(hc.AccessJwt), &testutil.CurlFailureConfig{
 		ShouldFail:   true,

--- a/check_upgrade/check_upgrade_test.go
+++ b/check_upgrade/check_upgrade_test.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"testing"
 	"time"
 
@@ -26,6 +27,9 @@ import (
 )
 
 func TestCheckUpgrade(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Skipping test on non-Linux platforms due to dgraph binary dependency")
+	}
 	conf := dgraphtest.NewClusterConfig().WithNumAlphas(1).WithNumZeros(1).WithReplicas(1).
 		WithACL(time.Hour).WithVersion("57aa5c4ac")
 	c, err := dgraphtest.NewLocalCluster(conf)

--- a/check_upgrade/check_upgrade_test.go
+++ b/check_upgrade/check_upgrade_test.go
@@ -10,6 +10,7 @@ package checkupgrade
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -27,8 +28,10 @@ import (
 )
 
 func TestCheckUpgrade(t *testing.T) {
-	if runtime.GOOS != "linux" {
-		t.Skip("Skipping test on non-Linux platforms due to dgraph binary dependency")
+	if runtime.GOOS != "linux" && os.Getenv("DGRAPH_BINARY") == "" {
+		fmt.Println("Skipping live load-uids tests on non-Linux platforms due to dgraph binary dependency")
+		fmt.Println("You can set the DGRAPH_BINARY environment variable to path of a native dgraph binary to run these tests")
+		os.Exit(0)
 	}
 	conf := dgraphtest.NewClusterConfig().WithNumAlphas(1).WithNumZeros(1).WithReplicas(1).
 		WithACL(time.Hour).WithVersion("57aa5c4ac")

--- a/dgraph/cmd/dgraphimport/import_test.go
+++ b/dgraph/cmd/dgraphimport/import_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -302,7 +303,8 @@ func runImportTest(t *testing.T, tt testcase) {
 
 // setupBulkCluster creates and configures a cluster for bulk loading data
 func setupBulkCluster(t *testing.T, numAlphas int, encrypted bool) (*dgraphtest.LocalCluster, string) {
-	if runtime.GOOS != "linux" {
+	if runtime.GOOS != "linux" && os.Getenv("DGRAPH_BINARY") == "" {
+		fmt.Println("You can set the DGRAPH_BINARY environment variable to path of a native dgraph binary to run these tests")
 		t.Skip("Skipping test on non-Linux platforms due to dgraph binary dependency")
 	}
 	baseDir := t.TempDir()

--- a/dgraph/cmd/dgraphimport/import_test.go
+++ b/dgraph/cmd/dgraphimport/import_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -301,6 +302,9 @@ func runImportTest(t *testing.T, tt testcase) {
 
 // setupBulkCluster creates and configures a cluster for bulk loading data
 func setupBulkCluster(t *testing.T, numAlphas int, encrypted bool) (*dgraphtest.LocalCluster, string) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Skipping test on non-Linux platforms due to dgraph binary dependency")
+	}
 	baseDir := t.TempDir()
 	bulkConf := dgraphtest.NewClusterConfig().
 		WithNumAlphas(numAlphas).

--- a/dgraph/cmd/increment/increment_test.go
+++ b/dgraph/cmd/increment/increment_test.go
@@ -124,7 +124,7 @@ func readBestEffort(t *testing.T, dg *dgo.Dgraph, pred string, M int) {
 }
 
 func setup(t *testing.T) *dgo.Dgraph {
-	dg, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
+	dg, err := testutil.DgraphClientWithGroot(testutil.GetSockAddr())
 	if err != nil {
 		t.Fatalf("Error while getting a dgraph client: %v", err)
 	}

--- a/dgraph/cmd/live/load-json/load_test.go
+++ b/dgraph/cmd/live/load-json/load_test.go
@@ -162,8 +162,9 @@ func TestLiveLoadJSONMultipleFiles(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	if runtime.GOOS != "linux" {
+	if runtime.GOOS != "linux" && os.Getenv("DGRAPH_BINARY") == "" {
 		fmt.Println("Skipping live load-json tests on non-Linux platforms due to dgraph binary dependency")
+		fmt.Println("You can set the DGRAPH_BINARY environment variable to path of a native dgraph binary to run these tests")
 		os.Exit(0)
 	}
 

--- a/dgraph/cmd/live/load-json/load_test.go
+++ b/dgraph/cmd/live/load-json/load_test.go
@@ -9,6 +9,7 @@ package live
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -22,7 +23,7 @@ import (
 	"github.com/hypermodeinc/dgraph/v25/x"
 )
 
-var alphaService = testutil.SockAddr
+var alphaService = testutil.GetSockAddr()
 
 var (
 	testDataDir string
@@ -161,11 +162,16 @@ func TestLiveLoadJSONMultipleFiles(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
+	if runtime.GOOS != "linux" {
+		fmt.Println("Skipping live load-json tests on non-Linux platforms due to dgraph binary dependency")
+		os.Exit(0)
+	}
+
 	_, thisFile, _, _ := runtime.Caller(0)
 	testDataDir = filepath.Dir(thisFile)
 
 	var err error
-	dg, err = testutil.DgraphClientWithGroot(testutil.SockAddr)
+	dg, err = testutil.DgraphClientWithGroot(testutil.GetSockAddr())
 	x.Panic(err)
 
 	// Try to create any files in a dedicated temp directory that gets cleaned up

--- a/dgraph/cmd/live/load-uids/load_test.go
+++ b/dgraph/cmd/live/load-uids/load_test.go
@@ -251,7 +251,7 @@ func TestLiveLoadExportedSchema(t *testing.T) {
 			  }
 			}`,
 	}
-	token := testutil.GrootHttpLogin("http://" + testutil.SockAddrHttp + "/admin")
+	token := testutil.GrootHttpLogin("http://" + testutil.GetSockAddrHttp() + "/admin")
 	resp := testutil.MakeGQLRequestWithAccessJwt(t, params, token.AccessJwt)
 	require.Nilf(t, resp.Errors, resp.Errors.Error())
 
@@ -351,8 +351,13 @@ func TestLiveLoadFileNameMultipleCorrect(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
+	if runtime.GOOS != "linux" {
+		fmt.Println("Skipping live load-uids tests on non-Linux platforms due to dgraph binary dependency")
+		os.Exit(0)
+	}
+
 	alphaName = testutil.Instance
-	alphaService = testutil.SockAddr
+	alphaService = testutil.GetSockAddr()
 
 	x.AssertTrue(strings.Count(alphaName, "_") == 2)
 	left := strings.Index(alphaName, "_")
@@ -365,7 +370,7 @@ func TestMain(m *testing.M) {
 	fmt.Printf("Using test data dir: %s\n", testDataDir)
 
 	var err error
-	dg, err = testutil.DgraphClientWithGroot(testutil.SockAddr)
+	dg, err = testutil.DgraphClientWithGroot(testutil.GetSockAddr())
 	if err != nil {
 		log.Fatalf("Error while getting a dgraph client: %v", err)
 	}

--- a/dgraph/cmd/live/load-uids/load_test.go
+++ b/dgraph/cmd/live/load-uids/load_test.go
@@ -351,15 +351,14 @@ func TestLiveLoadFileNameMultipleCorrect(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	if runtime.GOOS != "linux" {
+	if runtime.GOOS != "linux" && os.Getenv("DGRAPH_BINARY") == "" {
 		fmt.Println("Skipping live load-uids tests on non-Linux platforms due to dgraph binary dependency")
+		fmt.Println("You can set the DGRAPH_BINARY environment variable to path of a native dgraph binary to run these tests")
 		os.Exit(0)
 	}
 
-	alphaName = testutil.Instance
 	alphaService = testutil.GetSockAddr()
-
-	fmt.Println("⚠️ load_test.go/TestMain, alphaName: ", alphaName, " alphaService: ", alphaService)
+	alphaName = testutil.Instance
 
 	x.AssertTrue(strings.Count(alphaName, "_") == 2)
 	left := strings.Index(alphaName, "_")

--- a/dgraph/cmd/live/load-uids/load_test.go
+++ b/dgraph/cmd/live/load-uids/load_test.go
@@ -359,6 +359,8 @@ func TestMain(m *testing.M) {
 	alphaName = testutil.Instance
 	alphaService = testutil.GetSockAddr()
 
+	fmt.Println("⚠️ load_test.go/TestMain, alphaName: ", alphaName, " alphaService: ", alphaService)
+
 	x.AssertTrue(strings.Count(alphaName, "_") == 2)
 	left := strings.Index(alphaName, "_")
 	right := strings.LastIndex(alphaName, "_")

--- a/dgraph/cmd/version/version_test.go
+++ b/dgraph/cmd/version/version_test.go
@@ -19,8 +19,9 @@ import (
 
 // Test `dgraph version` with an empty config file.
 func TestMain(m *testing.M) {
-	if runtime.GOOS != "linux" {
+	if runtime.GOOS != "linux" && os.Getenv("DGRAPH_BINARY") == "" {
 		fmt.Println("Skipping version tests on non-Linux platforms due to dgraph binary dependency")
+		fmt.Println("You can set the DGRAPH_BINARY environment variable to path of a native dgraph binary to run these tests")
 		os.Exit(0)
 	}
 	m.Run()

--- a/dgraph/cmd/version/version_test.go
+++ b/dgraph/cmd/version/version_test.go
@@ -6,8 +6,10 @@
 package version
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -16,6 +18,14 @@ import (
 )
 
 // Test `dgraph version` with an empty config file.
+func TestMain(m *testing.M) {
+	if runtime.GOOS != "linux" {
+		fmt.Println("Skipping version tests on non-Linux platforms due to dgraph binary dependency")
+		os.Exit(0)
+	}
+	m.Run()
+}
+
 func TestDgraphVersion(t *testing.T) {
 	tmpPath := t.TempDir()
 	configPath := filepath.Join(tmpPath, "config.yml")

--- a/dgraph/cmd/zero/zero_test.go
+++ b/dgraph/cmd/zero/zero_test.go
@@ -41,7 +41,7 @@ func TestRemoveNode(t *testing.T) {
 
 func TestIdLeaseOverflow(t *testing.T) {
 	dialOpts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
-	con, err := grpc.NewClient(testutil.SockAddrZero, dialOpts...)
+	con, err := grpc.NewClient(testutil.GetSockAddrZero(), dialOpts...)
 	require.NoError(t, err)
 	zc := pb.NewZeroClient(con)
 
@@ -55,7 +55,7 @@ func TestIdLeaseOverflow(t *testing.T) {
 
 func TestIdBump(t *testing.T) {
 	dialOpts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
-	con, err := grpc.NewClient(testutil.SockAddrZero, dialOpts...)
+	con, err := grpc.NewClient(testutil.GetSockAddrZero(), dialOpts...)
 	require.NoError(t, err)
 	zc := pb.NewZeroClient(con)
 

--- a/dgraph/docker-compose.yml
+++ b/dgraph/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       service: zero
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${GOPATH:?GOPATH environment variable is required but not set}/bin
         target: /gobin
         read_only: true
     command:
@@ -32,7 +32,7 @@ services:
       service: zero
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${GOPATH:?GOPATH environment variable is required but not set}/bin
         target: /gobin
         read_only: true
     command:
@@ -52,7 +52,7 @@ services:
       service: zero
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${GOPATH:?GOPATH environment variable is required but not set}/bin
         target: /gobin
         read_only: true
     command:
@@ -64,7 +64,7 @@ services:
     working_dir: /data/alpha1
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${GOPATH:?GOPATH environment variable is required but not set}/bin
         target: /gobin
         read_only: true
       - type: bind
@@ -95,7 +95,7 @@ services:
       - alpha1
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${GOPATH:?GOPATH environment variable is required but not set}/bin
         target: /gobin
         read_only: true
       - type: bind
@@ -126,7 +126,7 @@ services:
       - alpha2
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${GOPATH:?GOPATH environment variable is required but not set}/bin
         target: /gobin
         read_only: true
       - type: bind
@@ -157,7 +157,7 @@ services:
       - alpha3
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${GOPATH:?GOPATH environment variable is required but not set}/bin
         target: /gobin
         read_only: true
       - type: bind
@@ -188,7 +188,7 @@ services:
       - alpha4
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${GOPATH:?GOPATH environment variable is required but not set}/bin
         target: /gobin
         read_only: true
       - type: bind
@@ -219,7 +219,7 @@ services:
       - alpha5
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${GOPATH:?GOPATH environment variable is required but not set}/bin
         target: /gobin
         read_only: true
       - type: bind

--- a/dgraphtest/compose_cluster.go
+++ b/dgraphtest/compose_cluster.go
@@ -21,7 +21,7 @@ func NewComposeCluster() *ComposeCluster {
 }
 
 func (c *ComposeCluster) Client() (*dgraphapi.GrpcClient, func(), error) {
-	dg, err := dgo.NewClient(testutil.SockAddr,
+	dg, err := dgo.NewClient(testutil.GetSockAddr(),
 		dgo.WithGrpcOption(grpc.WithTransportCredentials(insecure.NewCredentials())))
 	if err != nil {
 		return nil, nil, err
@@ -31,7 +31,7 @@ func (c *ComposeCluster) Client() (*dgraphapi.GrpcClient, func(), error) {
 
 // HTTPClient creates an HTTP client
 func (c *ComposeCluster) HTTPClient() (*dgraphapi.HTTPClient, error) {
-	httpClient, err := dgraphapi.GetHttpClient(testutil.SockAddrHttp, testutil.SockAddrZeroHttp)
+	httpClient, err := dgraphapi.GetHttpClient(testutil.GetSockAddrHttp(), testutil.GetSockAddrZeroHttp())
 	if err != nil {
 		return nil, err
 	}

--- a/dgraphtest/image.go
+++ b/dgraphtest/image.go
@@ -253,13 +253,6 @@ func IsHigherVersion(higher, lower string) (bool, error) {
 	cmd := exec.Command("git", "merge-base", "--is-ancestor", lower, higher)
 	cmd.Dir = repoDir
 	if out, err := cmd.CombinedOutput(); err != nil {
-		// This can happen in CI environments that do a shallow clone. If a commit
-		// doesn't exist, git returns a non-zero exit code. We check for the error
-		// message and assume that the local version is higher if the commit is not found.
-		if strings.Contains(string(out), "Not a valid commit name") {
-			return true, nil
-		}
-
 		if exitError, ok := err.(*exec.ExitError); ok && exitError.ExitCode() == 1 {
 			return false, nil
 		}

--- a/dgraphtest/image.go
+++ b/dgraphtest/image.go
@@ -253,6 +253,13 @@ func IsHigherVersion(higher, lower string) (bool, error) {
 	cmd := exec.Command("git", "merge-base", "--is-ancestor", lower, higher)
 	cmd.Dir = repoDir
 	if out, err := cmd.CombinedOutput(); err != nil {
+		// This can happen in CI environments that do a shallow clone. If a commit
+		// doesn't exist, git returns a non-zero exit code. We check for the error
+		// message and assume that the local version is higher if the commit is not found.
+		if strings.Contains(string(out), "Not a valid commit name") {
+			return true, nil
+		}
+
 		if exitError, ok := err.(*exec.ExitError); ok && exitError.ExitCode() == 1 {
 			return false, nil
 		}

--- a/graphql/e2e/schema/schema_test.go
+++ b/graphql/e2e/schema/schema_test.go
@@ -34,7 +34,7 @@ var (
 	groupOneHTTP   = testutil.ContainerAddr("alpha1", 8080)
 	groupTwoHTTP   = testutil.ContainerAddr("alpha2", 8080)
 	groupThreeHTTP = testutil.ContainerAddr("alpha3", 8080)
-	groupOnegRPC   = testutil.SockAddr
+	groupOnegRPC   = testutil.GetSockAddr()
 
 	groupOneGraphQLServer   = "http://" + groupOneHTTP + "/graphql"
 	groupTwoGraphQLServer   = "http://" + groupTwoHTTP + "/graphql"
@@ -681,7 +681,7 @@ func TestDeleteSchemaAndExport(t *testing.T) {
 
 	require.Equal(t, "Success", testutil.JsonGet(data, "export", "response", "code").(string))
 	taskId := testutil.JsonGet(data, "export", "taskId").(string)
-	testutil.WaitForTask(t, taskId, false, testutil.SockAddrHttp)
+	testutil.WaitForTask(t, taskId, false, testutil.GetSockAddrHttp())
 
 	// applying a new schema should still work
 	newSchemaResp := common.AssertUpdateGQLSchemaSuccess(t, groupOneHTTP, schema, nil)

--- a/query/common_test.go
+++ b/query/common_test.go
@@ -350,7 +350,7 @@ type DispatchBoardCard {
 
 `
 
-const ngramVersionHash = "5d9fd2ed444b9ca1d3b03e7a51f5f92fc407cbaa"
+const ngramVersionHash = "d7dfe3b4282fa3543e811c5538f86d39268961ba"
 
 func populateCluster(dc dgraphapi.Cluster) {
 	x.Panic(client.Alter(context.Background(), &api.Operation{DropAll: true}))

--- a/systest/1million/1million_test.go
+++ b/systest/1million/1million_test.go
@@ -44,8 +44,9 @@ func Test1Million(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	if runtime.GOOS != "linux" {
+	if runtime.GOOS != "linux" && os.Getenv("DGRAPH_BINARY") == "" {
 		fmt.Println("Skipping 1million tests on non-Linux platforms due to dgraph binary dependency")
+		fmt.Println("You can set the DGRAPH_BINARY environment variable to path of a native dgraph binary to run these tests")
 		os.Exit(0)
 	}
 	noschemaFile := filepath.Join(testutil.TestDataDirectory, "1million-noindex.schema")

--- a/systest/1million/1million_test.go
+++ b/systest/1million/1million_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -43,6 +44,10 @@ func Test1Million(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
+	if runtime.GOOS != "linux" {
+		fmt.Println("Skipping 1million tests on non-Linux platforms due to dgraph binary dependency")
+		os.Exit(0)
+	}
 	noschemaFile := filepath.Join(testutil.TestDataDirectory, "1million-noindex.schema")
 	rdfFile := filepath.Join(testutil.TestDataDirectory, "1million.rdf.gz")
 	if err := testutil.MakeDirEmpty([]string{"out/0", "out/1", "out/2"}); err != nil {
@@ -50,7 +55,7 @@ func TestMain(m *testing.M) {
 	}
 
 	if err := testutil.BulkLoad(testutil.BulkOpts{
-		Zero:       testutil.SockAddrZero,
+		Zero:       testutil.GetSockAddrZero(),
 		Shards:     1,
 		RdfFile:    rdfFile,
 		SchemaFile: noschemaFile,

--- a/systest/21million/bulk/run_test.go
+++ b/systest/21million/bulk/run_test.go
@@ -69,8 +69,9 @@ func BenchmarkQueries(b *testing.B) {
 }
 
 func TestMain(m *testing.M) {
-	if runtime.GOOS != "linux" {
+	if runtime.GOOS != "linux" && os.Getenv("DGRAPH_BINARY") == "" {
 		fmt.Println("Skipping 21million bulk tests on non-Linux platforms due to dgraph binary dependency")
+		fmt.Println("You can set the DGRAPH_BINARY environment variable to path of a native dgraph binary to run these tests")
 		os.Exit(0)
 	}
 	schemaFile := filepath.Join(testutil.TestDataDirectory, "21million.schema")

--- a/systest/21million/bulk/run_test.go
+++ b/systest/21million/bulk/run_test.go
@@ -69,6 +69,10 @@ func BenchmarkQueries(b *testing.B) {
 }
 
 func TestMain(m *testing.M) {
+	if runtime.GOOS != "linux" {
+		fmt.Println("Skipping 21million bulk tests on non-Linux platforms due to dgraph binary dependency")
+		os.Exit(0)
+	}
 	schemaFile := filepath.Join(testutil.TestDataDirectory, "21million.schema")
 	rdfFile := filepath.Join(testutil.TestDataDirectory, "21million.rdf.gz")
 	if err := testutil.MakeDirEmpty([]string{"out/0", "out/1", "out/2"}); err != nil {
@@ -76,7 +80,7 @@ func TestMain(m *testing.M) {
 	}
 
 	if err := testutil.BulkLoad(testutil.BulkOpts{
-		Zero:       testutil.SockAddrZero,
+		Zero:       testutil.GetSockAddrZero(),
 		Shards:     1,
 		RdfFile:    rdfFile,
 		SchemaFile: schemaFile,

--- a/systest/acl/restore/acl_restore_test.go
+++ b/systest/acl/restore/acl_restore_test.go
@@ -101,7 +101,7 @@ func TestAclCacheRestore(t *testing.T) {
 	dg := gc.Dgraph
 
 	sendRestoreRequest(t, "/backups", "vibrant_euclid5", 1)
-	testutil.WaitForRestore(t, dg, testutil.SockAddrHttp)
+	testutil.WaitForRestore(t, dg, testutil.GetSockAddrHttp())
 
 	token, err := testutil.Login(t,
 		&testutil.LoginParams{UserID: "alice1", Passwd: "password", Namespace: 0})

--- a/systest/audit/audit_test.go
+++ b/systest/audit/audit_test.go
@@ -26,11 +26,11 @@ func TestZeroAudit(t *testing.T) {
 	defer os.RemoveAll(fmt.Sprintf("audit_dir/za/zero_audit_0_%s.log", nId))
 	zeroCmd := map[string][]string{
 		"/removeNode": {`--location`, "--request", "GET", "--ipv4",
-			fmt.Sprintf("%s/removeNode?id=3&group=1", testutil.SockAddrZeroHttp)},
+			fmt.Sprintf("%s/removeNode?id=3&group=1", testutil.GetSockAddrZeroHttp())},
 		"/assign": {"--location", "--request", "GET", "--ipv4",
-			fmt.Sprintf("%s/assign?what=uids&num=100", testutil.SockAddrZeroHttp)},
+			fmt.Sprintf("%s/assign?what=uids&num=100", testutil.GetSockAddrZeroHttp())},
 		"/moveTablet": {"--location", "--request", "GET", "--ipv4",
-			fmt.Sprintf("%s/moveTablet?tablet=name&group=2", testutil.SockAddrZeroHttp)}}
+			fmt.Sprintf("%s/moveTablet?tablet=name&group=2", testutil.GetSockAddrZeroHttp())}}
 
 	msgs := make([]string, 0)
 	// logger is buffered. make calls in bunch so that dont want to wait for flush
@@ -58,21 +58,21 @@ func TestAlphaAudit(t *testing.T) {
 	defer os.Remove(fmt.Sprintf("audit_dir/aa/alpha_audit_1_%s.log", nId))
 	testCommand := map[string][]string{
 		"/admin": {"--location", "--request", "POST", "--ipv4",
-			fmt.Sprintf("%s/admin", testutil.SockAddrHttp),
+			fmt.Sprintf("%s/admin", testutil.GetSockAddrHttp()),
 			"--header", "Content-Type: application/json",
 			"--data-raw", `'{"query":"mutation {\n  backup(
 input: {destination: \"/Users/sankalanparajuli/work/backup\"}) {\n    response {\n      message\n      code\n    }\n  }\n}\n","variables":{}}'`}, //nolint:lll
 
-		"/graphql": {"--location", "--request", "POST", "--ipv4", fmt.Sprintf("%s/graphql", testutil.SockAddrHttp),
+		"/graphql": {"--location", "--request", "POST", "--ipv4", fmt.Sprintf("%s/graphql", testutil.GetSockAddrHttp()),
 			"--header", "Content-Type: application/json",
 			"--data-raw", `'{"query":"query {\n  __schema {\n    __typename\n  }\n}","variables":{}}'`},
 
-		"/alter": {"-X", "POST", "--ipv4", fmt.Sprintf("%s/alter", testutil.SockAddrHttp), "-d",
+		"/alter": {"-X", "POST", "--ipv4", fmt.Sprintf("%s/alter", testutil.GetSockAddrHttp()), "-d",
 			`name: string @index(term) .
 			type Person {
 			  name
 			}`},
-		"/query": {"-H", "'Content-Type: application/dql'", "-X", "POST", "--ipv4", fmt.Sprintf("%s/query", testutil.SockAddrHttp),
+		"/query": {"-H", "'Content-Type: application/dql'", "-X", "POST", "--ipv4", fmt.Sprintf("%s/query", testutil.GetSockAddrHttp()),
 			"-d", `$'
 			{
 			 balances(func: anyofterms(name, "Alice Bob")) {
@@ -82,7 +82,7 @@ input: {destination: \"/Users/sankalanparajuli/work/backup\"}) {\n    response {
 			 }
 			}'`},
 		"/mutate": {"-H", "'Content-Type: application/rdf'", "-X",
-			"POST", "--ipv4", fmt.Sprintf("%s/mutate?startTs=4", testutil.SockAddrHttp), "-d", `$'
+			"POST", "--ipv4", fmt.Sprintf("%s/mutate?startTs=4", testutil.GetSockAddrHttp()), "-d", `$'
 			{
 			 set {
 			   <0x1> <balance> "110" .

--- a/systest/audit_encrypted/audit_test.go
+++ b/systest/audit_encrypted/audit_test.go
@@ -21,8 +21,9 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	if runtime.GOOS != "linux" {
+	if runtime.GOOS != "linux" && os.Getenv("DGRAPH_BINARY") == "" {
 		fmt.Println("Skipping audit_encrypted tests on non-Linux platforms due to dgraph binary dependency")
+		fmt.Println("You can set the DGRAPH_BINARY environment variable to path of a native dgraph binary to run these tests")
 		os.Exit(0)
 	}
 	m.Run()

--- a/systest/audit_encrypted/audit_test.go
+++ b/systest/audit_encrypted/audit_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -18,6 +19,14 @@ import (
 	"github.com/hypermodeinc/dgraph/v25/testutil"
 	"github.com/hypermodeinc/dgraph/v25/testutil/testaudit"
 )
+
+func TestMain(m *testing.M) {
+	if runtime.GOOS != "linux" {
+		fmt.Println("Skipping audit_encrypted tests on non-Linux platforms due to dgraph binary dependency")
+		os.Exit(0)
+	}
+	m.Run()
+}
 
 func TestZeroAuditEncrypted(t *testing.T) {
 	state, err := testutil.GetState()
@@ -27,11 +36,11 @@ func TestZeroAuditEncrypted(t *testing.T) {
 	defer os.RemoveAll(fmt.Sprintf("audit_dir/za/zero_audit_0_%s.log.enc", nId))
 	zeroCmd := map[string][]string{
 		"/removeNode": {`--location`, "--request", "GET", "--ipv4",
-			fmt.Sprintf("%s/removeNode?id=3&group=1", testutil.SockAddrZeroHttp)},
+			fmt.Sprintf("%s/removeNode?id=3&group=1", testutil.GetSockAddrZeroHttp())},
 		"/assign": {"--location", "--request", "GET", "--ipv4",
-			fmt.Sprintf("%s/assign?what=uids&num=100", testutil.SockAddrZeroHttp)},
+			fmt.Sprintf("%s/assign?what=uids&num=100", testutil.GetSockAddrZeroHttp())},
 		"/moveTablet": {"--location", "--request", "GET", "--ipv4",
-			fmt.Sprintf("%s/moveTablet?tablet=name&group=2", testutil.SockAddrZeroHttp)}}
+			fmt.Sprintf("%s/moveTablet?tablet=name&group=2", testutil.GetSockAddrZeroHttp())}}
 
 	msgs := make([]string, 0)
 	// logger is buffered. make calls in bunch so that dont want to wait for flush
@@ -77,21 +86,21 @@ func TestAlphaAuditEncrypted(t *testing.T) {
 	defer os.Remove(fmt.Sprintf("audit_dir/aa/alpha_audit_1_%s.log.enc", nId))
 	testCommand := map[string][]string{
 		"/admin": {"--location", "--request", "POST", "--ipv4",
-			fmt.Sprintf("%s/admin", testutil.SockAddrHttp),
+			fmt.Sprintf("%s/admin", testutil.GetSockAddrHttp()),
 			"--header", "Content-Type: application/json",
 			"--data-raw", `'{"query":"mutation {\n  backup(
 input: {destination: \"/Users/sankalanparajuli/work/backup\"}) {\n    response {\n      message\n      code\n    }\n  }\n}\n","variables":{}}'`}, //nolint:lll
 
-		"/graphql": {"--location", "--request", "POST", "--ipv4", fmt.Sprintf("%s/graphql", testutil.SockAddrHttp),
+		"/graphql": {"--location", "--request", "POST", "--ipv4", fmt.Sprintf("%s/graphql", testutil.GetSockAddrHttp()),
 			"--header", "Content-Type: application/json",
 			"--data-raw", `'{"query":"query {\n  __schema {\n    __typename\n  }\n}","variables":{}}'`},
 
-		"/alter": {"-X", "POST", "--ipv4", fmt.Sprintf("%s/alter", testutil.SockAddrHttp), "-d",
+		"/alter": {"-X", "POST", "--ipv4", fmt.Sprintf("%s/alter", testutil.GetSockAddrHttp()), "-d",
 			`name: string @index(term) .
 			type Person {
 			  name
 			}`},
-		"/query": {"-H", "'Content-Type: application/dql'", "--ipv4", "-X", "POST", fmt.Sprintf("%s/query", testutil.SockAddrHttp),
+		"/query": {"-H", "'Content-Type: application/dql'", "--ipv4", "-X", "POST", fmt.Sprintf("%s/query", testutil.GetSockAddrHttp()),
 			"-d", `$'
 			{
 			 balances(func: anyofterms(name, "Alice Bob")) {
@@ -101,7 +110,7 @@ input: {destination: \"/Users/sankalanparajuli/work/backup\"}) {\n    response {
 			 }
 			}'`},
 		"/mutate": {"-H", "'Content-Type: application/rdf'", "--ipv4", "-X",
-			"POST", fmt.Sprintf("%s/mutate?startTs=4", testutil.SockAddrHttp), "-d", `$'
+			"POST", fmt.Sprintf("%s/mutate?startTs=4", testutil.GetSockAddrHttp()), "-d", `$'
 			{
 			 set {
 			   <0x1> <balance> "110" .

--- a/systest/backup/encryption/backup_test.go
+++ b/systest/backup/encryption/backup_test.go
@@ -55,7 +55,7 @@ func TestBackupMinioE(t *testing.T) {
 		// internal-port
 		true))
 
-	dg, err := testutil.DgraphClientWithCerts(testutil.SockAddr, conf)
+	dg, err := testutil.DgraphClientWithCerts(testutil.GetSockAddr(), conf)
 	require.NoError(t, err)
 	mc, err = testutil.NewMinioClient()
 	require.NoError(t, err)
@@ -87,7 +87,7 @@ func TestBackupMinioE(t *testing.T) {
 	client := testutil.GetHttpsClient(t)
 	tabletName := x.NamespaceAttr(x.RootNamespace, "movie")
 	// Move tablet to group 1 to avoid messes later.
-	_, err = client.Get("https://" + testutil.SockAddrZeroHttp + "/moveTablet?tablet=movie&group=1")
+	_, err = client.Get("https://" + testutil.GetSockAddrZeroHttp() + "/moveTablet?tablet=movie&group=1")
 	require.NoError(t, err)
 
 	// After the move, we need to pause a bit to give zero a chance to quorum.
@@ -259,7 +259,7 @@ func runBackupInternal(t *testing.T, forceFull bool, numExpectedFiles,
 		}
 	}`
 
-	adminUrl := "https://" + testutil.SockAddrHttp + "/admin"
+	adminUrl := "https://" + testutil.GetSockAddrHttp() + "/admin"
 	params := testutil.GraphQLParams{
 		Query: backupRequest,
 		Variables: map[string]interface{}{
@@ -278,7 +278,7 @@ func runBackupInternal(t *testing.T, forceFull bool, numExpectedFiles,
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&data))
 	require.Equal(t, "Success", testutil.JsonGet(data, "data", "backup", "response", "code").(string))
 	taskId := testutil.JsonGet(data, "data", "backup", "taskId").(string)
-	testutil.WaitForTask(t, taskId, true, testutil.SockAddrHttp)
+	testutil.WaitForTask(t, taskId, true, testutil.GetSockAddrHttp())
 
 	// Verify that the right amount of files and directories were created.
 	copyToLocalFs(t)

--- a/systest/backup/filesystem/backup_test.go
+++ b/systest/backup/filesystem/backup_test.go
@@ -77,7 +77,7 @@ func TestBackupOfOldRestore(t *testing.T) {
 	common.DirSetup(t)
 	common.CopyOldBackupDir(t)
 
-	conn, err := grpc.NewClient(testutil.SockAddr, grpc.WithTransportCredentials(credentials.NewTLS(testutil.GetAlphaClientConfig(t))))
+	conn, err := grpc.NewClient(testutil.GetSockAddr(), grpc.WithTransportCredentials(credentials.NewTLS(testutil.GetAlphaClientConfig(t))))
 	require.NoError(t, err)
 	dg := dgo.NewDgraphClient(api.NewDgraphClient(conn))
 	require.NoError(t, err)
@@ -88,7 +88,7 @@ func TestBackupOfOldRestore(t *testing.T) {
 	_ = runBackup(t, 3, 1)
 
 	sendRestoreRequest(t, oldBackupDir1)
-	testutil.WaitForRestore(t, dg, testutil.SockAddrHttp)
+	testutil.WaitForRestore(t, dg, testutil.GetSockAddrHttp())
 
 	q := `{ authors(func: has(Author.name)) { count(uid) } }`
 	resp, err := dg.NewTxn().Query(context.Background(), q)
@@ -101,7 +101,7 @@ func TestBackupOfOldRestore(t *testing.T) {
 	testutil.DropAll(t, dg)
 	time.Sleep(2 * time.Second)
 	sendRestoreRequest(t, alphaBackupDir)
-	testutil.WaitForRestore(t, dg, testutil.SockAddrHttp)
+	testutil.WaitForRestore(t, dg, testutil.GetSockAddrHttp())
 
 	resp, err = dg.NewTxn().Query(context.Background(), q)
 	require.NoError(t, err)
@@ -118,7 +118,7 @@ func TestRestoreOfOldBackup(t *testing.T) {
 		common.DirSetup(t)
 		common.CopyOldBackupDir(t)
 
-		conn, err := grpc.NewClient(testutil.SockAddr,
+		conn, err := grpc.NewClient(testutil.GetSockAddr(),
 			grpc.WithTransportCredentials(credentials.NewTLS(testutil.GetAlphaClientConfig(t))))
 		require.NoError(t, err)
 		dg := dgo.NewDgraphClient(api.NewDgraphClient(conn))
@@ -128,7 +128,7 @@ func TestRestoreOfOldBackup(t *testing.T) {
 		time.Sleep(2 * time.Second)
 
 		sendRestoreRequest(t, dir)
-		testutil.WaitForRestore(t, dg, testutil.SockAddrHttp)
+		testutil.WaitForRestore(t, dg, testutil.GetSockAddrHttp())
 
 		queryAndCheck := func(pred string, cnt int) {
 			q := fmt.Sprintf(`{ me(func: has(%s)) { count(uid) } }`, pred)
@@ -148,7 +148,7 @@ func TestRestoreOfOldBackup(t *testing.T) {
 }
 
 func TestBackupFilesystem(t *testing.T) {
-	conn, err := grpc.NewClient(testutil.SockAddr,
+	conn, err := grpc.NewClient(testutil.GetSockAddr(),
 		grpc.WithTransportCredentials(credentials.NewTLS(testutil.GetAlphaClientConfig(t))))
 	require.NoError(t, err)
 	dg := dgo.NewDgraphClient(api.NewDgraphClient(conn))
@@ -190,7 +190,7 @@ func TestBackupFilesystem(t *testing.T) {
 
 	// Move tablet to group 1 to avoid messes later.
 	client := testutil.GetHttpsClient(t)
-	_, err = client.Get("https://" + testutil.SockAddrZeroHttp + "/moveTablet?tablet=movie&group=1")
+	_, err = client.Get("https://" + testutil.GetSockAddrZeroHttp() + "/moveTablet?tablet=movie&group=1")
 	require.NoError(t, err)
 
 	// After the move, we need to pause a bit to give zero a chance to quorum.
@@ -403,7 +403,7 @@ func runBackupInternal(t *testing.T, forceFull bool, numExpectedFiles,
 			}
 		}`
 
-	adminUrl := "https://" + testutil.SockAddrHttp + "/admin"
+	adminUrl := "https://" + testutil.GetSockAddrHttp() + "/admin"
 	params := testutil.GraphQLParams{
 		Query: backupRequest,
 		Variables: map[string]interface{}{
@@ -424,7 +424,7 @@ func runBackupInternal(t *testing.T, forceFull bool, numExpectedFiles,
 	require.Equal(t, "Success",
 		testutil.JsonGet(data, "data", "backup", "response", "code").(string))
 	taskId := testutil.JsonGet(data, "data", "backup", "taskId").(string)
-	testutil.WaitForTask(t, taskId, true, testutil.SockAddrHttp)
+	testutil.WaitForTask(t, taskId, true, testutil.GetSockAddrHttp())
 
 	// Verify that the right amount of files and directories were created.
 	common.CopyToLocalFs(t)

--- a/systest/backup/minio-large/backup_test.go
+++ b/systest/backup/minio-large/backup_test.go
@@ -47,7 +47,7 @@ var (
 // Test to add a large database and verify backup and restore work as expected.
 func TestBackupMinioLarge(t *testing.T) {
 	// backupDestination = "minio://" + testutil.DockerPrefix + "_minio_1:9001/dgraph-backup?secure=false"
-	conn, err := grpc.NewClient(testutil.SockAddr,
+	conn, err := grpc.NewClient(testutil.GetSockAddr(),
 		grpc.WithTransportCredentials(credentials.NewTLS(testutil.GetAlphaClientConfig(t))))
 	require.NoError(t, err)
 	dg := dgo.NewDgraphClient(api.NewDgraphClient(conn))
@@ -89,13 +89,13 @@ func setupTablets(t *testing.T, dg *dgo.Dgraph) {
 				 name2: string .
 				 name3: string .`}))
 	client := testutil.GetHttpsClient(t)
-	_, err := client.Get("https://" + testutil.SockAddrZeroHttp + "/moveTablet?tablet=name1&group=1")
+	_, err := client.Get("https://" + testutil.GetSockAddrZeroHttp() + "/moveTablet?tablet=name1&group=1")
 	require.NoError(t, err)
 	time.Sleep(time.Second)
-	_, err = client.Get("https://" + testutil.SockAddrZeroHttp + "/moveTablet?tablet=name2&group=2")
+	_, err = client.Get("https://" + testutil.GetSockAddrZeroHttp() + "/moveTablet?tablet=name2&group=2")
 	require.NoError(t, err)
 	time.Sleep(time.Second)
-	_, err = client.Get("https://" + testutil.SockAddrZeroHttp + "/moveTablet?tablet=name3&group=3")
+	_, err = client.Get("https://" + testutil.GetSockAddrZeroHttp() + "/moveTablet?tablet=name3&group=3")
 	require.NoError(t, err)
 
 	// After the move, we need to pause a bit to give zero a chance to quorum.
@@ -145,7 +145,7 @@ func runBackup(t *testing.T) {
 		}
 	}`
 
-	adminUrl := "https://" + testutil.SockAddrHttp + "/admin"
+	adminUrl := "https://" + testutil.GetSockAddrHttp() + "/admin"
 	params := testutil.GraphQLParams{
 		Query: backupRequest,
 		Variables: map[string]interface{}{
@@ -165,7 +165,7 @@ func runBackup(t *testing.T) {
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&data))
 	require.Equal(t, "Success", testutil.JsonGet(data, "data", "backup", "response", "code").(string))
 	taskId := testutil.JsonGet(data, "data", "backup", "taskId").(string)
-	testutil.WaitForTask(t, taskId, true, testutil.SockAddrHttp)
+	testutil.WaitForTask(t, taskId, true, testutil.GetSockAddrHttp())
 
 	// Verify that the right amount of files and directories were created.
 	copyToLocalFs(t)

--- a/systest/backup/minio/backup_test.go
+++ b/systest/backup/minio/backup_test.go
@@ -49,7 +49,7 @@ func TestBackupMinio(t *testing.T) {
 	addr := testutil.ContainerAddr("minio", 9001)
 	localBackupDst = "minio://" + addr + "/dgraph-backup?secure=false"
 
-	conn, err := grpc.NewClient(testutil.SockAddr,
+	conn, err := grpc.NewClient(testutil.GetSockAddr(),
 		grpc.WithTransportCredentials(credentials.NewTLS(testutil.GetAlphaClientConfig(t))))
 	require.NoError(t, err)
 	dg := dgo.NewDgraphClient(api.NewDgraphClient(conn))
@@ -83,7 +83,7 @@ func TestBackupMinio(t *testing.T) {
 
 	// Move tablet to group 1 to avoid messes later.
 	client := testutil.GetHttpsClient(t)
-	_, err = client.Get("https://" + testutil.SockAddrZeroHttp + "/moveTablet?tablet=movie&group=1")
+	_, err = client.Get("https://" + testutil.GetSockAddrZeroHttp() + "/moveTablet?tablet=movie&group=1")
 	require.NoError(t, err)
 
 	// After the move, we need to pause a bit to give zero a chance to quorum.
@@ -284,7 +284,7 @@ func runBackupInternal(t *testing.T, forceFull bool, numExpectedFiles,
 		}
 	}`
 
-	adminUrl := "https://" + testutil.SockAddrHttp + "/admin"
+	adminUrl := "https://" + testutil.GetSockAddrHttp() + "/admin"
 	params := testutil.GraphQLParams{
 		Query: backupRequest,
 		Variables: map[string]interface{}{
@@ -304,7 +304,7 @@ func runBackupInternal(t *testing.T, forceFull bool, numExpectedFiles,
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&data))
 	require.Equal(t, "Success", testutil.JsonGet(data, "data", "backup", "response", "code").(string))
 	taskId := testutil.JsonGet(data, "data", "backup", "taskId").(string)
-	testutil.WaitForTask(t, taskId, true, testutil.SockAddrHttp)
+	testutil.WaitForTask(t, taskId, true, testutil.GetSockAddrHttp())
 
 	// Verify that the right amount of files and directories were created.
 	copyToLocalFs(t)

--- a/systest/backup/multi-tenancy/backup_test.go
+++ b/systest/backup/multi-tenancy/backup_test.go
@@ -95,7 +95,7 @@ func TestBackupMultiTenancy(t *testing.T) {
 	_ = runBackup(t, galaxyToken, 3, 1)
 	testutil.DropAll(t, dg)
 	sendRestoreRequest(t, alphaBackupDir, galaxyToken.AccessJwt)
-	testutil.WaitForRestore(t, dg, testutil.SockAddrHttp)
+	testutil.WaitForRestore(t, dg, testutil.GetSockAddrHttp())
 
 	query := `{ q(func: has(movie)) { count(uid) } }`
 	expectedResponse := `{ "q": [{ "count": 5 }]}`
@@ -109,7 +109,7 @@ func TestBackupMultiTenancy(t *testing.T) {
 	_ = runBackup(t, galaxyToken, 6, 2)
 	testutil.DropAll(t, dg)
 	sendRestoreRequest(t, alphaBackupDir, galaxyToken.AccessJwt)
-	testutil.WaitForRestore(t, dg, testutil.SockAddrHttp)
+	testutil.WaitForRestore(t, dg, testutil.GetSockAddrHttp())
 	testutil.VerifyQueryResponse(t, dg, query, expectedResponse)
 	testutil.VerifyQueryResponse(t, dg1, query, expectedResponse)
 	testutil.VerifyQueryResponse(t, dg2, query, `{ "q": [{ "count": 0 }]}`)
@@ -120,7 +120,7 @@ func TestBackupMultiTenancy(t *testing.T) {
 	_ = runBackup(t, galaxyToken, 9, 3)
 	testutil.DropAll(t, dg)
 	sendRestoreRequest(t, alphaBackupDir, galaxyToken.AccessJwt)
-	testutil.WaitForRestore(t, dg, testutil.SockAddrHttp)
+	testutil.WaitForRestore(t, dg, testutil.GetSockAddrHttp())
 	query = `{ q(func: has(movie)) { count(uid) } }`
 	expectedResponse = `{ "q": [{ "count": 5 }]}`
 	testutil.VerifyQueryResponse(t, dg, query, expectedResponse)
@@ -158,7 +158,7 @@ func runBackupInternal(t *testing.T, token *testutil.HttpToken, forceFull bool, 
 	require.NoError(t, json.Unmarshal(resp.Data, &data))
 	require.Equal(t, "Success", testutil.JsonGet(data, "backup", "response", "code").(string))
 	taskId := testutil.JsonGet(data, "backup", "taskId").(string)
-	testutil.WaitForTask(t, taskId, false, testutil.SockAddrHttp)
+	testutil.WaitForTask(t, taskId, false, testutil.GetSockAddrHttp())
 
 	// Verify that the right amount of files and directories were created.
 	common.CopyToLocalFs(t)

--- a/systest/backup/nfs-backup/backup_test.go
+++ b/systest/backup/nfs-backup/backup_test.go
@@ -40,14 +40,14 @@ var (
 
 func TestBackupHAClust(t *testing.T) {
 
-	backupRestoreTest(t, testutil.SockAddr, testutil.SockAddrAlpha4Http,
-		testutil.SockAddrZeroHttp, backupDstHA, testutil.SockAddrHttp)
+	backupRestoreTest(t, testutil.GetSockAddr(), testutil.GetSockAddrAlpha4Http(),
+		testutil.GetSockAddrZeroHttp(), backupDstHA, testutil.GetSockAddrHttp())
 }
 
 func TestBackupNonHAClust(t *testing.T) {
 
-	backupRestoreTest(t, testutil.SockAddrAlpha7, testutil.SockAddrAlpha8Http,
-		testutil.SockAddrZero7Http, backupDstNonHA, testutil.SockAddrAlpha7Http)
+	backupRestoreTest(t, testutil.GetSockAddrAlpha7(), testutil.GetSockAddrAlpha8Http(),
+		testutil.GetSockAddrZero7Http(), backupDstNonHA, testutil.GetSockAddrAlpha7Http())
 }
 
 func backupRestoreTest(t *testing.T, backupAlphaSocketAddr string, restoreAlphaAddr string,

--- a/systest/bgindex/count_test.go
+++ b/systest/bgindex/count_test.go
@@ -40,7 +40,7 @@ func TestCountIndex(t *testing.T) {
 	var dg *dgo.Dgraph
 	err := x.RetryUntilSuccess(10, time.Second, func() error {
 		var err error
-		dg, err = testutil.DgraphClientWithGroot(testutil.SockAddr)
+		dg, err = testutil.DgraphClientWithGroot(testutil.GetSockAddr())
 		return err
 	})
 	require.NoError(t, err)

--- a/systest/bgindex/parallel_test.go
+++ b/systest/bgindex/parallel_test.go
@@ -56,7 +56,7 @@ func TestParallelIndexing(t *testing.T) {
 	var dg *dgo.Dgraph
 	err := x.RetryUntilSuccess(10, time.Second, func() error {
 		var err error
-		dg, err = testutil.DgraphClientWithGroot(testutil.SockAddr)
+		dg, err = testutil.DgraphClientWithGroot(testutil.GetSockAddr())
 		return err
 	})
 	require.NoError(t, err)

--- a/systest/bgindex/reverse_test.go
+++ b/systest/bgindex/reverse_test.go
@@ -34,7 +34,7 @@ func TestReverseIndex(t *testing.T) {
 	var dg *dgo.Dgraph
 	err := x.RetryUntilSuccess(10, time.Second, func() error {
 		var err error
-		dg, err = testutil.DgraphClientWithGroot(testutil.SockAddr)
+		dg, err = testutil.DgraphClientWithGroot(testutil.GetSockAddr())
 		return err
 	})
 	require.NoError(t, err)

--- a/systest/bgindex/string_test.go
+++ b/systest/bgindex/string_test.go
@@ -39,7 +39,7 @@ func TestStringIndex(t *testing.T) {
 	var dg *dgo.Dgraph
 	err := x.RetryUntilSuccess(10, time.Second, func() error {
 		var err error
-		dg, err = testutil.DgraphClientWithGroot(testutil.SockAddr)
+		dg, err = testutil.DgraphClientWithGroot(testutil.GetSockAddr())
 		return err
 	})
 	require.NoError(t, err)

--- a/systest/cdc/cdc_test.go
+++ b/systest/cdc/cdc_test.go
@@ -24,11 +24,13 @@ import (
 )
 
 func TestCDC(t *testing.T) {
-	if runtime.GOOS != "linux" {
+	if runtime.GOOS != "linux" && os.Getenv("DGRAPH_BINARY") == "" {
+		fmt.Println("You can set the DGRAPH_BINARY environment variable to path of a native dgraph binary to run these tests")
 		t.Skip("Skipping test on non-Linux platforms due to dgraph binary dependency")
 	}
 	defer os.RemoveAll("./cdc_logs/sink.log")
-	cmd := exec.Command("dgraph", "increment", "--num", "10",
+	path := testutil.DgraphBinaryPath()
+	cmd := exec.Command(path, "increment", "--num", "10",
 		"--alpha", testutil.GetSockAddr())
 	if out, err := cmd.CombinedOutput(); err != nil {
 		fmt.Println(string(out))

--- a/systest/cdc/cdc_test.go
+++ b/systest/cdc/cdc_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -23,9 +24,12 @@ import (
 )
 
 func TestCDC(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Skipping test on non-Linux platforms due to dgraph binary dependency")
+	}
 	defer os.RemoveAll("./cdc_logs/sink.log")
 	cmd := exec.Command("dgraph", "increment", "--num", "10",
-		"--alpha", testutil.SockAddr)
+		"--alpha", testutil.GetSockAddr())
 	if out, err := cmd.CombinedOutput(); err != nil {
 		fmt.Println(string(out))
 		t.Fatal(err)

--- a/systest/export/export_test.go
+++ b/systest/export/export_test.go
@@ -32,8 +32,9 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	if runtime.GOOS != "linux" {
+	if runtime.GOOS != "linux" && os.Getenv("DGRAPH_BINARY") == "" {
 		fmt.Println("Skipping export tests on non-Linux platforms due to dgraph binary dependency")
+		fmt.Println("You can set the DGRAPH_BINARY environment variable to path of a native dgraph binary to run these tests")
 		os.Exit(0)
 	}
 	m.Run()

--- a/systest/group-delete/group_delete_test.go
+++ b/systest/group-delete/group_delete_test.go
@@ -175,7 +175,7 @@ func TestNodes(t *testing.T) {
 	require.NoError(t, err)
 
 	for pred := range state1.Groups["2"].Tablets {
-		moveUrl := fmt.Sprintf("http://"+testutil.SockAddrZeroHttp+"/moveTablet?tablet=%s&group=1",
+		moveUrl := fmt.Sprintf("http://"+testutil.GetSockAddrZeroHttp()+"/moveTablet?tablet=%s&group=1",
 			url.QueryEscape(pred))
 		resp, err := http.Get(moveUrl)
 		require.NoError(t, err)
@@ -192,7 +192,7 @@ func TestNodes(t *testing.T) {
 
 	groupNodes, err = testutil.GetNodesInGroup("2")
 	require.NoError(t, err)
-	resp, err := http.Get("http://" + testutil.SockAddrZeroHttp + "/removeNode?group=2&id=" +
+	resp, err := http.Get("http://" + testutil.GetSockAddrZeroHttp() + "/removeNode?group=2&id=" +
 		groupNodes[0])
 	require.NoError(t, err)
 	require.NoError(t, getError(resp.Body))

--- a/systest/integration2/bulk_loader_test.go
+++ b/systest/integration2/bulk_loader_test.go
@@ -8,6 +8,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -64,7 +65,8 @@ const (
 )
 
 func TestBulkLoaderNoDqlSchema(t *testing.T) {
-	if runtime.GOOS != "linux" {
+	if runtime.GOOS != "linux" && os.Getenv("DGRAPH_BINARY") == "" {
+		fmt.Println("You can set the DGRAPH_BINARY environment variable to path of a native dgraph binary to run these tests")
 		t.Skip("Skipping test on non-Linux platforms due to dgraph binary dependency")
 	}
 	conf := dgraphtest.NewClusterConfig().WithNumAlphas(2).WithNumZeros(1).

--- a/systest/integration2/bulk_loader_test.go
+++ b/systest/integration2/bulk_loader_test.go
@@ -10,6 +10,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -63,6 +64,9 @@ const (
 )
 
 func TestBulkLoaderNoDqlSchema(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Skipping test on non-Linux platforms due to dgraph binary dependency")
+	}
 	conf := dgraphtest.NewClusterConfig().WithNumAlphas(2).WithNumZeros(1).
 		WithACL(time.Hour).WithReplicas(1).WithBulkLoadOutDir(t.TempDir())
 	c, err := dgraphtest.NewLocalCluster(conf)

--- a/systest/ldbc/ldbc_test.go
+++ b/systest/ldbc/ldbc_test.go
@@ -72,8 +72,9 @@ func TestQueries(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	if runtime.GOOS != "linux" {
+	if runtime.GOOS != "linux" && os.Getenv("DGRAPH_BINARY") == "" {
 		fmt.Println("Skipping LDBC tests on non-Linux platforms due to dgraph binary dependency")
+		fmt.Println("You can set the DGRAPH_BINARY environment variable to path of a native dgraph binary to run these tests")
 		os.Exit(0)
 	}
 	noschemaFile := filepath.Join(testutil.TestDataDirectory, "ldbcTypes.schema")

--- a/systest/ldbc/ldbc_test.go
+++ b/systest/ldbc/ldbc_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -71,6 +72,10 @@ func TestQueries(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
+	if runtime.GOOS != "linux" {
+		fmt.Println("Skipping LDBC tests on non-Linux platforms due to dgraph binary dependency")
+		os.Exit(0)
+	}
 	noschemaFile := filepath.Join(testutil.TestDataDirectory, "ldbcTypes.schema")
 	rdfFile := testutil.TestDataDirectory
 	if err := testutil.MakeDirEmpty([]string{"out/0"}); err != nil {
@@ -80,7 +85,7 @@ func TestMain(m *testing.M) {
 	start := time.Now()
 	fmt.Println("Bulkupload started")
 	if err := testutil.BulkLoad(testutil.BulkOpts{
-		Zero:       testutil.SockAddrZero,
+		Zero:       testutil.GetSockAddrZero(),
 		Shards:     1,
 		RdfFile:    rdfFile,
 		SchemaFile: noschemaFile,

--- a/systest/live_pw_test.go
+++ b/systest/live_pw_test.go
@@ -22,7 +22,7 @@ import (
 func TestLivePassword(t *testing.T) {
 	wrap := func(fn func(*testing.T, *dgo.Dgraph)) func(*testing.T) {
 		return func(t *testing.T) {
-			dg, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
+			dg, err := testutil.DgraphClientWithGroot(testutil.GetSockAddr())
 			if err != nil {
 				t.Fatalf("Error while getting a dgraph client: %v", err)
 			}

--- a/systest/loader/loader_test.go
+++ b/systest/loader/loader_test.go
@@ -24,8 +24,9 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	if runtime.GOOS != "linux" {
+	if runtime.GOOS != "linux" && os.Getenv("DGRAPH_BINARY") == "" {
 		fmt.Println("Skipping loader tests on non-Linux platforms due to dgraph binary dependency")
+		fmt.Println("You can set the DGRAPH_BINARY environment variable to path of a native dgraph binary to run these tests")
 		os.Exit(0)
 	}
 	m.Run()

--- a/systest/loader/loader_test.go
+++ b/systest/loader/loader_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -21,6 +22,14 @@ import (
 	"github.com/hypermodeinc/dgraph/v25/testutil"
 	"github.com/hypermodeinc/dgraph/v25/x"
 )
+
+func TestMain(m *testing.M) {
+	if runtime.GOOS != "linux" {
+		fmt.Println("Skipping loader tests on non-Linux platforms due to dgraph binary dependency")
+		os.Exit(0)
+	}
+	m.Run()
+}
 
 // TestLoaderXidmap checks that live loader re-uses xidmap on loading data from two different files
 func TestLoaderXidmap(t *testing.T) {
@@ -39,7 +48,7 @@ func TestLoaderXidmap(t *testing.T) {
 		// internal-port
 		true))
 
-	dg, err := testutil.DgraphClientWithCerts(testutil.SockAddrLocalhost, conf)
+	dg, err := testutil.DgraphClientWithCerts(testutil.GetSockAddrLocalhost(), conf)
 	require.NoError(t, err)
 	ctx := context.Background()
 	testutil.DropAll(t, dg)
@@ -67,8 +76,8 @@ func TestLoaderXidmap(t *testing.T) {
 	err = testutil.ExecWithOpts([]string{testutil.DgraphBinaryPath(), "live",
 		"--tls", tlsFlag,
 		"--files", data,
-		"--alpha", testutil.SockAddrLocalhost,
-		"--zero", testutil.SockAddrZeroLocalhost,
+		"--alpha", testutil.GetSockAddrLocalhost(),
+		"--zero", testutil.GetSockAddrZeroLocalhost(),
 		"-x", "x"}, testutil.CmdOpts{Dir: tmpDir})
 	require.NoError(t, err)
 
@@ -78,8 +87,8 @@ func TestLoaderXidmap(t *testing.T) {
 	err = testutil.ExecWithOpts([]string{testutil.DgraphBinaryPath(), "live",
 		"--tls", tlsFlag,
 		"--files", data,
-		"--alpha", testutil.SockAddrLocalhost,
-		"--zero", testutil.SockAddrZeroLocalhost,
+		"--alpha", testutil.GetSockAddrLocalhost(),
+		"--zero", testutil.GetSockAddrZeroLocalhost(),
 		"-x", "x"}, testutil.CmdOpts{Dir: tmpDir})
 	require.NoError(t, err)
 

--- a/systest/online-restore/online_restore_test.go
+++ b/systest/online-restore/online_restore_test.go
@@ -205,7 +205,7 @@ func runMutations(t *testing.T, dg *dgo.Dgraph) {
 func TestBasicRestore(t *testing.T) {
 	disableDraining(t)
 
-	conn, err := grpc.NewClient(testutil.SockAddr,
+	conn, err := grpc.NewClient(testutil.GetSockAddr(),
 		grpc.WithTransportCredentials(credentials.NewTLS(testutil.GetAlphaClientConfig(t))))
 	require.NoError(t, err)
 	dg := dgo.NewDgraphClient(api.NewDgraphClient(conn))
@@ -216,7 +216,7 @@ func TestBasicRestore(t *testing.T) {
 	snapshotTs := getSnapshotTs(t)
 	req := &restoreReq{location: backupLocation, backupId: "youthful_rhodes3", encKeyFile: encKeyFile}
 	sendRestoreRequest(t, req)
-	testutil.WaitForRestore(t, dg, testutil.SockAddrHttp)
+	testutil.WaitForRestore(t, dg, testutil.GetSockAddrHttp())
 
 	// Snapshot must be taken just after the restore and hence the snapshotTs be updated.
 	require.NoError(t, x.RetryUntilSuccess(3, 2*time.Second, func() error {
@@ -244,7 +244,7 @@ func TestBasicRestore(t *testing.T) {
 // drop all
 // Take backup b6
 func TestIncrementalRestore(t *testing.T) {
-	conn, err := grpc.NewClient(testutil.SockAddr,
+	conn, err := grpc.NewClient(testutil.GetSockAddr(),
 		grpc.WithTransportCredentials(credentials.NewTLS(testutil.GetAlphaClientConfig(t))))
 	require.NoError(t, err)
 	dg := dgo.NewDgraphClient(api.NewDgraphClient(conn))
@@ -257,7 +257,7 @@ func TestIncrementalRestore(t *testing.T) {
 		backupNum: 1,
 	}
 	sendRestoreRequest(t, req)
-	testutil.WaitForRestore(t, dg, testutil.SockAddrHttp)
+	testutil.WaitForRestore(t, dg, testutil.GetSockAddrHttp())
 
 	query := `{ q(func: has(name)) { name age } }`
 	runQuery := func(query, expectedResp string) {
@@ -273,7 +273,7 @@ func TestIncrementalRestore(t *testing.T) {
 		incrementalFrom: 2,
 	}
 	sendRestoreRequest(t, req)
-	testutil.WaitForRestore(t, dg, testutil.SockAddrHttp)
+	testutil.WaitForRestore(t, dg, testutil.GetSockAddrHttp())
 	runQuery(query, `{"q":[{"name":"alice"}, {"name":"bob", "age": "12"}]}`)
 
 	req = &restoreReq{
@@ -282,7 +282,7 @@ func TestIncrementalRestore(t *testing.T) {
 		incrementalFrom: 3,
 	}
 	sendRestoreRequest(t, req)
-	testutil.WaitForRestore(t, dg, testutil.SockAddrHttp)
+	testutil.WaitForRestore(t, dg, testutil.GetSockAddrHttp())
 	runQuery(query, `{"q":[]}`)
 	runQuery(`{ q(func: has(age)) {age} }`, `{"q":[{"age": "12"}]}`)
 
@@ -292,7 +292,7 @@ func TestIncrementalRestore(t *testing.T) {
 		incrementalFrom: 4,
 	}
 	sendRestoreRequest(t, req)
-	testutil.WaitForRestore(t, dg, testutil.SockAddrHttp)
+	testutil.WaitForRestore(t, dg, testutil.GetSockAddrHttp())
 	runQuery(query, `{"q":[{"name":"alice"}]}`)
 
 	req = &restoreReq{
@@ -302,7 +302,7 @@ func TestIncrementalRestore(t *testing.T) {
 	}
 
 	sendRestoreRequest(t, req)
-	testutil.WaitForRestore(t, dg, testutil.SockAddrHttp)
+	testutil.WaitForRestore(t, dg, testutil.GetSockAddrHttp())
 	runQuery(query, `{"q":[]}`)
 	runQuery(`{ q(func: has(age)) {age} }`, `{"q":[]}`)
 
@@ -320,7 +320,7 @@ func TestIncrementalRestore(t *testing.T) {
 
 	// after drop all
 	sendRestoreRequest(t, req)
-	testutil.WaitForRestore(t, dg, testutil.SockAddrHttp)
+	testutil.WaitForRestore(t, dg, testutil.GetSockAddrHttp())
 	runQuery(query, `{"q":[]}`)
 	runQuery(`{ q(func: has(age)) {age} }`, `{"q":[]}`)
 
@@ -334,7 +334,7 @@ func TestRestoreBackupNum(t *testing.T) {
 	disableDraining(t)
 
 	conn, err := grpc.NewClient(
-		testutil.SockAddr,
+		testutil.GetSockAddr(),
 		grpc.WithTransportCredentials(credentials.NewTLS(testutil.GetAlphaClientConfig(t))),
 	)
 	require.NoError(t, err)
@@ -346,7 +346,7 @@ func TestRestoreBackupNum(t *testing.T) {
 
 	req := &restoreReq{location: backupLocation, backupId: "youthful_rhodes3", backupNum: 1, encKeyFile: encKeyFile}
 	sendRestoreRequest(t, req)
-	testutil.WaitForRestore(t, dg, testutil.SockAddrHttp)
+	testutil.WaitForRestore(t, dg, testutil.GetSockAddrHttp())
 
 	runQueries(t, dg, true)
 	runMutations(t, dg)
@@ -356,7 +356,7 @@ func TestRestoreBackupNumInvalid(t *testing.T) {
 	disableDraining(t)
 
 	conn, err := grpc.NewClient(
-		testutil.SockAddr,
+		testutil.GetSockAddr(),
 		grpc.WithTransportCredentials(credentials.NewTLS(testutil.GetAlphaClientConfig(t))),
 	)
 	require.NoError(t, err)
@@ -416,7 +416,7 @@ func TestMoveTablets(t *testing.T) {
 	disableDraining(t)
 
 	conn, err := grpc.NewClient(
-		testutil.SockAddr,
+		testutil.GetSockAddr(),
 		grpc.WithTransportCredentials(credentials.NewTLS(testutil.GetAlphaClientConfig(t))),
 	)
 	require.NoError(t, err)
@@ -427,14 +427,14 @@ func TestMoveTablets(t *testing.T) {
 
 	req := &restoreReq{location: backupLocation, backupId: "youthful_rhodes3", encKeyFile: encKeyFile}
 	sendRestoreRequest(t, req)
-	testutil.WaitForRestore(t, dg, testutil.SockAddrHttp)
+	testutil.WaitForRestore(t, dg, testutil.GetSockAddrHttp())
 	runQueries(t, dg, false)
 
 	// Send another restore request with a different backup. This backup has some of the
 	// same predicates as the previous one but they are stored in different groups.
 	req = &restoreReq{location: backupLocation, backupId: "blissful_hermann1", encKeyFile: encKeyFile}
 	sendRestoreRequest(t, req)
-	testutil.WaitForRestore(t, dg, testutil.SockAddrHttp)
+	testutil.WaitForRestore(t, dg, testutil.GetSockAddrHttp())
 
 	resp, err := dg.NewTxn().Query(context.Background(), `{
 	  q(func: has(name), orderasc: name) {
@@ -514,7 +514,7 @@ func TestListBackups(t *testing.T) {
 }
 
 func TestRestoreWithDropOperations(t *testing.T) {
-	conn, err := grpc.NewClient(testutil.SockAddr,
+	conn, err := grpc.NewClient(testutil.GetSockAddr(),
 		grpc.WithTransportCredentials(credentials.NewTLS(testutil.GetAlphaClientConfig(t))))
 	require.NoError(t, err)
 	dg := dgo.NewDgraphClient(api.NewDgraphClient(conn))
@@ -713,7 +713,7 @@ func backupRestoreAndVerify(t *testing.T, dg *dgo.Dgraph, backupDir, queryToVeri
 	backup(t, backupDir)
 	req := &restoreReq{location: backupDir, encKeyFile: encKeyFile}
 	sendRestoreRequest(t, req)
-	testutil.WaitForRestore(t, dg, testutil.SockAddrHttp)
+	testutil.WaitForRestore(t, dg, testutil.GetSockAddrHttp())
 	testutil.VerifyQueryResponse(t, dg, queryToVerify, expectedResponse)
 	testutil.VerifySchema(t, dg, schemaVerificationOpts)
 }

--- a/testutil/client.go
+++ b/testutil/client.go
@@ -107,7 +107,6 @@ func init() {
 // This uses sync.Once to ensure thread-safe lazy initialization
 func ensureAddressesInitialized() {
 	addressInitOnce.Do(func() {
-		// If DockerPrefix is empty, provide fallback default addresses
 		if DockerPrefix == "" {
 			// Use default ports when no Docker containers are available
 			MinioInstance = "localhost:9001"
@@ -134,6 +133,8 @@ func ensureAddressesInitialized() {
 			sockAddrZero4 = "localhost:5080"
 			sockAddrZero4Http = "localhost:6080"
 		} else {
+			Instance = fmt.Sprintf("%s_%s_1", DockerPrefix, "alpha1")
+
 			// Define container configurations for multi-threaded resolution
 			type containerConfig struct {
 				name         string
@@ -179,9 +180,6 @@ func ensureAddressesInitialized() {
 					}
 				}(config)
 			}
-
-			// Set Instance separately as it's not a container address
-			Instance = fmt.Sprintf("%s_%s_1", DockerPrefix, "alpha1")
 
 			// Wait for all goroutines to complete
 			wg.Wait()

--- a/testutil/docker.go
+++ b/testutil/docker.go
@@ -67,8 +67,9 @@ func (in ContainerInstance) BestEffortWaitForHealthy(privatePort uint16) error {
 		return nil
 	}
 
+	maxAttempts := 60
 	tryWith := func(host string) error {
-		for range 60 {
+		for range maxAttempts {
 			resp, err := http.Get("http://" + host + ":" + port + "/health")
 			var body []byte
 			if resp != nil && resp.Body != nil {
@@ -84,8 +85,10 @@ func (in ContainerInstance) BestEffortWaitForHealthy(privatePort uint16) error {
 					continue
 				}
 			}
-			fmt.Printf("Health for %s failed: %v. Response: %q. Retrying...\n", in, err, body)
-			time.Sleep(time.Second)
+			if !strings.Contains(string(body), "Please retry again") {
+				fmt.Printf("Health for %s failed: %v. Response: %q. Retrying...\n", in, err, body)
+			}
+			time.Sleep(500 * time.Millisecond)
 		}
 		return fmt.Errorf("did not pass health check on %s", "http://"+host+":"+port+"/health\n")
 	}

--- a/testutil/docker.go
+++ b/testutil/docker.go
@@ -80,12 +80,14 @@ func (in ContainerInstance) BestEffortWaitForHealthy(privatePort uint16) error {
 				if aerr := checkACL(body); aerr == nil {
 					return nil
 				} else {
-					fmt.Printf("waiting for login to work: %v\n", aerr)
+					if maxAttempts > 10 {
+						fmt.Printf("waiting for login to work: %v\n", aerr)
+					}
 					time.Sleep(time.Second)
 					continue
 				}
 			}
-			if !strings.Contains(string(body), "Please retry again") {
+			if maxAttempts > 10 {
 				fmt.Printf("Health for %s failed: %v. Response: %q. Retrying...\n", in, err, body)
 			}
 			time.Sleep(500 * time.Millisecond)

--- a/testutil/docker.go
+++ b/testutil/docker.go
@@ -67,9 +67,9 @@ func (in ContainerInstance) BestEffortWaitForHealthy(privatePort uint16) error {
 		return nil
 	}
 
-	maxAttempts := 60
 	tryWith := func(host string) error {
-		for range maxAttempts {
+		maxAttempts := 60
+		for attempt := range maxAttempts {
 			resp, err := http.Get("http://" + host + ":" + port + "/health")
 			var body []byte
 			if resp != nil && resp.Body != nil {
@@ -80,14 +80,14 @@ func (in ContainerInstance) BestEffortWaitForHealthy(privatePort uint16) error {
 				if aerr := checkACL(body); aerr == nil {
 					return nil
 				} else {
-					if maxAttempts > 10 {
+					if attempt > 10 {
 						fmt.Printf("waiting for login to work: %v\n", aerr)
 					}
 					time.Sleep(time.Second)
 					continue
 				}
 			}
-			if maxAttempts > 10 {
+			if attempt > 10 {
 				fmt.Printf("Health for %s failed: %v. Response: %q. Retrying...\n", in, err, body)
 			}
 			time.Sleep(500 * time.Millisecond)

--- a/testutil/graphql.go
+++ b/testutil/graphql.go
@@ -91,11 +91,12 @@ func MakeGQLRequestWithAccessJwt(t *testing.T, params *GraphQLParams, accessToke
 func MakeGQLRequestWithAccessJwtAndTLS(t *testing.T, params *GraphQLParams,
 	tls *tls.Config, accessToken string) *GraphQLResponse {
 
+	ensureAddressesInitialized()
 	var adminUrl string
 	if tls != nil {
-		adminUrl = "https://" + SockAddrHttp + "/admin"
+		adminUrl = "https://" + GetSockAddrHttp() + "/admin"
 	} else {
-		adminUrl = "http://" + SockAddrHttp + "/admin"
+		adminUrl = "http://" + GetSockAddrHttp() + "/admin"
 	}
 
 	b, err := json.Marshal(params)

--- a/testutil/minio.go
+++ b/testutil/minio.go
@@ -6,14 +6,44 @@
 package testutil
 
 import (
+	"context"
+	"fmt"
+	"time"
+
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 )
 
 // NewMinioClient returns a minio client.
 func NewMinioClient() (*minio.Client, error) {
-	return minio.New(MinioInstance, &minio.Options{
+	ensureAddressesInitialized()
+	if MinioInstance == "" {
+		return nil, fmt.Errorf("testutil.MinioInstance is not set")
+	}
+
+	mc, err := minio.New(MinioInstance, &minio.Options{
 		Creds:  credentials.NewStaticV4("accesskey", "secretkey", ""),
 		Secure: false,
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	var errHealthCheck error
+	for i := 0; i < 5; i++ {
+		// Use a short timeout for the health check to avoid long waits.
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+
+		// BucketExists is a lightweight call to check for connectivity.
+		// We don't care about the result, just that it doesn't error.
+		_, errHealthCheck = mc.BucketExists(ctx, "healthcheck")
+		if errHealthCheck == nil {
+			cancel()
+			return mc, nil
+		}
+		cancel()
+		time.Sleep(time.Second)
+	}
+
+	return nil, fmt.Errorf("minio client not ready: %w", errHealthCheck)
 }

--- a/testutil/minio.go
+++ b/testutil/minio.go
@@ -13,7 +13,8 @@ import (
 // NewMinioClient returns a minio client.
 func NewMinioClient() (*minio.Client, error) {
 	return minio.New(MinioInstance, &minio.Options{
-		Creds:  credentials.NewStaticV4("accesskey", "secretkey", ""),
-		Secure: false,
+		Creds:      credentials.NewStaticV4("accesskey", "secretkey", ""),
+		Secure:     false,
+		MaxRetries: 20,
 	})
 }

--- a/testutil/minio.go
+++ b/testutil/minio.go
@@ -13,8 +13,7 @@ import (
 // NewMinioClient returns a minio client.
 func NewMinioClient() (*minio.Client, error) {
 	return minio.New(MinioInstance, &minio.Options{
-		Creds:      credentials.NewStaticV4("accesskey", "secretkey", ""),
-		Secure:     false,
-		MaxRetries: 20,
+		Creds:  credentials.NewStaticV4("accesskey", "secretkey", ""),
+		Secure: false,
 	})
 }

--- a/testutil/multi_tenancy.go
+++ b/testutil/multi_tenancy.go
@@ -339,7 +339,8 @@ func AddRulesToGroup(t *testing.T, token *HttpToken, group string, rules []Rule,
 }
 
 func DgClientWithLogin(t *testing.T, id, password string, ns uint64) *dgo.Dgraph {
-	userClient, err := DgraphClient(SockAddr)
+	ensureAddressesInitialized()
+	userClient, err := DgraphClient(GetSockAddr())
 	require.NoError(t, err)
 
 	require.NoError(t, x.RetryUntilSuccess(10, 100*time.Millisecond, func() error {

--- a/testutil/testaudit/audit.go
+++ b/testutil/testaudit/audit.go
@@ -53,11 +53,11 @@ func TestGenerateAuditForTestDecrypt(t *testing.T) {
 	t.Skip()
 	zeroCmd := map[string][]string{
 		"/removeNode": {`--location`, "--request", "GET", "--ipv4",
-			fmt.Sprintf("%s/removeNode?id=3&group=1", testutil.SockAddrZeroHttp)},
+			fmt.Sprintf("%s/removeNode?id=3&group=1", testutil.GetSockAddrZeroHttp())},
 		"/assign": {"--location", "--request", "GET", "--ipv4",
-			fmt.Sprintf("%s/assign?what=uids&num=100", testutil.SockAddrZeroHttp)},
+			fmt.Sprintf("%s/assign?what=uids&num=100", testutil.GetSockAddrZeroHttp())},
 		"/moveTablet": {"--location", "--request", "GET", "--ipv4",
-			fmt.Sprintf("%s/moveTablet?tablet=name&group=2", testutil.SockAddrZeroHttp)}}
+			fmt.Sprintf("%s/moveTablet?tablet=name&group=2", testutil.GetSockAddrZeroHttp())}}
 
 	for _, c := range zeroCmd {
 		cmd := exec.Command("curl", c...)

--- a/testutil/zero.go
+++ b/testutil/zero.go
@@ -52,7 +52,8 @@ type StateResponse struct {
 
 // GetState queries the /state endpoint in zero and returns the response.
 func GetState() (*StateResponse, error) {
-	resp, err := http.Get("http://" + SockAddrZeroHttp + "/state")
+	ensureAddressesInitialized()
+	resp, err := http.Get("http://" + GetSockAddrZeroHttp() + "/state")
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +86,8 @@ func GetStateHttps(tlsConfig *tls.Config) (*StateResponse, error) {
 			TLSClientConfig: tlsConfig,
 		},
 	}
-	resp, err := client.Get("https://" + SockAddrZeroHttp + "/state")
+	ensureAddressesInitialized()
+	resp, err := client.Get("https://" + GetSockAddrZeroHttp() + "/state")
 	if err != nil {
 		return nil, err
 	}

--- a/tlstest/acl/acl_over_tls_test.go
+++ b/tlstest/acl/acl_over_tls_test.go
@@ -28,7 +28,7 @@ func TestLoginOverTLS(t *testing.T) {
 		// server-name
 		"alpha1"))
 
-	dg, err := testutil.DgraphClientWithCerts(testutil.SockAddr, conf)
+	dg, err := testutil.DgraphClientWithCerts(testutil.GetSockAddr(), conf)
 	require.NoError(t, err)
 	for i := 0; i < 30; i++ {
 		err = dg.LoginIntoNamespace(context.Background(), "groot", "password", x.RootNamespace)

--- a/tlstest/certrequest/certrequest_test.go
+++ b/tlstest/certrequest/certrequest_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestAccessOverPlaintext(t *testing.T) {
-	dg, err := testutil.DgraphClient(testutil.SockAddr)
+	dg, err := testutil.DgraphClient(testutil.GetSockAddr())
 	if err != nil {
 		t.Fatalf("Error while getting a dgraph client: %v", err)
 	}
@@ -37,7 +37,7 @@ func TestAccessWithCaCert(t *testing.T) {
 		// server-name
 		"node"))
 
-	dg, err := testutil.DgraphClientWithCerts(testutil.SockAddr, conf)
+	dg, err := testutil.DgraphClientWithCerts(testutil.GetSockAddr(), conf)
 	require.NoError(t, err, "Unable to get dgraph client: %v", err)
 	for i := 0; i < 20; i++ {
 		err := dg.Alter(context.Background(), &api.Operation{DropAll: true})
@@ -56,7 +56,7 @@ func TestCurlAccessWithCaCert(t *testing.T) {
 	// curl over plaintext should fail
 	curlPlainTextArgs := []string{
 		"--ipv4",
-		"https://" + testutil.SockAddrHttpLocalhost + "/alter",
+		"https://" + testutil.GetSockAddrHttpLocalhost() + "/alter",
 		"-d", "name: string @index(exact) .",
 	}
 	testutil.VerifyCurlCmd(t, curlPlainTextArgs, &testutil.CurlFailureConfig{
@@ -66,7 +66,7 @@ func TestCurlAccessWithCaCert(t *testing.T) {
 
 	curlArgs := []string{
 		"--cacert", "../tls/ca.crt", "--ipv4",
-		"https://" + testutil.SockAddrHttpLocalhost + "/alter",
+		"https://" + testutil.GetSockAddrHttpLocalhost() + "/alter",
 		"-d", "name: string @index(exact) .",
 	}
 	testutil.VerifyCurlCmd(t, curlArgs, &testutil.CurlFailureConfig{

--- a/tlstest/certverifyifgiven/certverifyifgiven_test.go
+++ b/tlstest/certverifyifgiven/certverifyifgiven_test.go
@@ -27,7 +27,7 @@ func TestAccessWithoutClientCert(t *testing.T) {
 		// server-name
 		"node"))
 
-	dg, err := testutil.DgraphClientWithCerts(testutil.SockAddrLocalhost, conf)
+	dg, err := testutil.DgraphClientWithCerts(testutil.GetSockAddrLocalhost(), conf)
 	require.NoError(t, err, "Unable to get dgraph client: %v", err)
 	require.NoError(t, dg.Alter(context.Background(), &api.Operation{DropAll: true}))
 }
@@ -44,14 +44,14 @@ func TestAccessWithClientCert(t *testing.T) {
 		// client-key
 		"../tls/client.acl.key"))
 
-	dg, err := testutil.DgraphClientWithCerts(testutil.SockAddrLocalhost, conf)
+	dg, err := testutil.DgraphClientWithCerts(testutil.GetSockAddrLocalhost(), conf)
 	require.NoError(t, err, "Unable to get dgraph client: %v", err)
 	require.NoError(t, dg.Alter(context.Background(), &api.Operation{DropAll: true}))
 }
 
 func TestCurlAccessWithoutClientCert(t *testing.T) {
 	curlArgs := []string{
-		"--cacert", "../tls/ca.crt", "https://" + testutil.SockAddrHttpLocalhost + "/alter",
+		"--cacert", "../tls/ca.crt", "https://" + testutil.GetSockAddrHttpLocalhost() + "/alter",
 		"-d", "name: string @index(exact) .",
 	}
 	testutil.VerifyCurlCmd(t, curlArgs, &testutil.CurlFailureConfig{
@@ -64,7 +64,7 @@ func TestCurlAccessWithClientCert(t *testing.T) {
 		"--cacert", "../tls/ca.crt",
 		"--cert", "../tls/client.acl.crt",
 		"--key", "../tls/client.acl.key",
-		"https://" + testutil.SockAddrHttpLocalhost + "/alter",
+		"https://" + testutil.GetSockAddrHttpLocalhost() + "/alter",
 		"-d", "name: string @index(exact) .",
 	}
 	testutil.VerifyCurlCmd(t, curlArgs, &testutil.CurlFailureConfig{

--- a/tlstest/mtls_internal/multi_group/multi_group_test.go
+++ b/tlstest/mtls_internal/multi_group/multi_group_test.go
@@ -92,7 +92,7 @@ func TestClusterSetupWithMultiGroup(t *testing.T) {
 	}
 	tlsConf, err := x.GenerateClientTLSConfig(c)
 	require.NoError(t, err)
-	dgConn, err := grpc.NewClient(testutil.SockAddr, grpc.WithTransportCredentials(credentials.NewTLS(tlsConf)))
+	dgConn, err := grpc.NewClient(testutil.GetSockAddr(), grpc.WithTransportCredentials(credentials.NewTLS(tlsConf)))
 	require.NoError(t, err)
 	client := dgo.NewDgraphClient(api.NewDgraphClient(dgConn))
 	runTests(t, client)

--- a/tlstest/mtls_internal/single_node/single_node_test.go
+++ b/tlstest/mtls_internal/single_node/single_node_test.go
@@ -92,7 +92,7 @@ func TestClusterSetup(t *testing.T) {
 	}
 	tlsConf, err := x.GenerateClientTLSConfig(c)
 	require.NoError(t, err)
-	dgConn, err := grpc.NewClient(testutil.SockAddr, grpc.WithTransportCredentials(credentials.NewTLS(tlsConf)))
+	dgConn, err := grpc.NewClient(testutil.GetSockAddr(), grpc.WithTransportCredentials(credentials.NewTLS(tlsConf)))
 	require.NoError(t, err)
 	client := dgo.NewDgraphClient(api.NewDgraphClient(dgConn))
 	runTests(t, client)

--- a/tlstest/zero_https/all_routes_tls/all_routes_tls_test.go
+++ b/tlstest/zero_https/all_routes_tls/all_routes_tls_test.go
@@ -53,7 +53,7 @@ func TestZeroWithAllRoutesTLSWithHTTPClient(t *testing.T) {
 	}
 	defer client.CloseIdleConnections()
 	for _, test := range testCasesHttp {
-		request, err := http.NewRequest("GET", "http://"+testutil.SockAddrZeroHttp+test.url, nil)
+		request, err := http.NewRequest("GET", "http://"+testutil.GetSockAddrZeroHttp()+test.url, nil)
 		require.NoError(t, err)
 		do, err := client.Do(request)
 		require.NoError(t, err)
@@ -97,7 +97,7 @@ func TestZeroWithAllRoutesTLSWithTLSClient(t *testing.T) {
 
 	defer client.CloseIdleConnections()
 	for _, test := range testCasesHttps {
-		request, err := http.NewRequest("GET", "https://"+testutil.SockAddrZeroHttp+test.url, nil)
+		request, err := http.NewRequest("GET", "https://"+testutil.GetSockAddrZeroHttp()+test.url, nil)
 		require.NoError(t, err)
 		do, err := client.Do(request)
 		require.NoError(t, err)

--- a/tlstest/zero_https/no_tls/no_tls_test.go
+++ b/tlstest/zero_https/no_tls/no_tls_test.go
@@ -44,7 +44,7 @@ func TestZeroWithNoTLS(t *testing.T) {
 	}
 	defer client.CloseIdleConnections()
 	for _, test := range testCasesHttp {
-		request, err := http.NewRequest("GET", "http://"+testutil.SockAddrZeroHttp+test.url, nil)
+		request, err := http.NewRequest("GET", "http://"+testutil.GetSockAddrZeroHttp()+test.url, nil)
 		require.NoError(t, err)
 		do, err := client.Do(request)
 		require.NoError(t, err)

--- a/worker/export_test.go
+++ b/worker/export_test.go
@@ -390,7 +390,7 @@ const exportRequest = `mutation export($format: String!) {
 }`
 
 func TestExportFormat(t *testing.T) {
-	adminUrl := "http://" + testutil.SockAddrHttp + "/admin"
+	adminUrl := "http://" + testutil.GetSockAddrHttp() + "/admin"
 	require.NoError(t, testutil.CheckForGraphQLEndpointToReady(t))
 
 	params := testutil.GraphQLParams{
@@ -407,7 +407,7 @@ func TestExportFormat(t *testing.T) {
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&data))
 	require.Equal(t, "Success", testutil.JsonGet(data, "data", "export", "response", "code").(string))
 	taskId := testutil.JsonGet(data, "data", "export", "taskId").(string)
-	testutil.WaitForTask(t, taskId, false, testutil.SockAddrHttp)
+	testutil.WaitForTask(t, taskId, false, testutil.GetSockAddrHttp())
 
 	params.Variables["format"] = "rdf"
 	b, err = json.Marshal(params)

--- a/worker/snapshot_test.go
+++ b/worker/snapshot_test.go
@@ -28,7 +28,7 @@ import (
 func TestSnapshot(t *testing.T) {
 	snapshotTs := uint64(0)
 
-	dg1, err := testutil.DgraphClient(testutil.SockAddr)
+	dg1, err := testutil.DgraphClient(testutil.GetSockAddr())
 	if err != nil {
 		t.Fatalf("Error while getting a dgraph client: %v", err)
 	}
@@ -92,7 +92,7 @@ func TestSnapshot(t *testing.T) {
 	const testSchema = "type Person { name: String }"
 	// uploading new schema while alpha2 is not running so we can
 	// test whether the stopped alpha gets new schema in snapshot
-	testutil.UpdateGQLSchema(t, testutil.SockAddrHttp, testSchema)
+	testutil.UpdateGQLSchema(t, testutil.GetSockAddrHttp(), testSchema)
 	_ = waitForSnapshot(t, snapshotTs)
 
 	t.Logf("Starting alpha2.\n")
@@ -161,7 +161,7 @@ func verifySnapshot(t *testing.T, dg *dgo.Dgraph, num int) {
 func waitForSnapshot(t *testing.T, prevSnapTs uint64) uint64 {
 	snapPattern := `"snapshotTs":"([0-9]*)"`
 	for {
-		res, err := http.Get("http://" + testutil.SockAddrZeroHttp + "/state")
+		res, err := http.Get("http://" + testutil.GetSockAddrZeroHttp() + "/state")
 		require.NoError(t, err)
 		body, err := io.ReadAll(res.Body)
 		res.Body.Close()

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -148,7 +148,7 @@ func initTest(t *testing.T, schemaStr string) {
 }
 
 func initClusterTest(t *testing.T, schemaStr string) *dgo.Dgraph {
-	dg, err := testutil.DgraphClient(testutil.SockAddr)
+	dg, err := testutil.DgraphClient(testutil.GetSockAddr())
 	if err != nil {
 		t.Fatalf("Error while getting a dgraph client: %v", err)
 	}
@@ -239,7 +239,7 @@ func runQuery(dg *dgo.Dgraph, attr string, uids []uint64, srcFunc []string) (*ap
 }
 
 func BenchmarkEqFilter(b *testing.B) {
-	dg, err := testutil.DgraphClient(testutil.SockAddr)
+	dg, err := testutil.DgraphClient(testutil.GetSockAddr())
 	if err != nil {
 		panic(err)
 	}
@@ -343,7 +343,7 @@ func TestProcessTaskIndexMLayer(t *testing.T) {
 
 func TestCountReverseIndex(t *testing.T) {
 	schemaStr := "friend: [uid] @count ."
-	dg, err := testutil.DgraphClient(testutil.SockAddr)
+	dg, err := testutil.DgraphClient(testutil.GetSockAddr())
 	if err != nil {
 		t.Fatalf("Error while getting a dgraph client: %v", err)
 	}
@@ -385,7 +385,7 @@ func TestCountReverseIndex(t *testing.T) {
 
 func TestCountIndexOverwrite(t *testing.T) {
 	schemaStr := "friend: [uid] @reverse @count ."
-	dg, err := testutil.DgraphClient(testutil.SockAddr)
+	dg, err := testutil.DgraphClient(testutil.GetSockAddr())
 	if err != nil {
 		t.Fatalf("Error while getting a dgraph client: %v", err)
 	}
@@ -407,7 +407,7 @@ func TestCountIndexOverwrite(t *testing.T) {
 
 func TestCountReverseWithDeletes(t *testing.T) {
 	schemaStr := "friend: [uid] @reverse @count ."
-	dg, err := testutil.DgraphClient(testutil.SockAddr)
+	dg, err := testutil.DgraphClient(testutil.GetSockAddr())
 	if err != nil {
 		t.Fatalf("Error while getting a dgraph client: %v", err)
 	}

--- a/xidmap/xidmap_test.go
+++ b/xidmap/xidmap_test.go
@@ -46,7 +46,7 @@ func getTestXidmapOpts(conn *grpc.ClientConn, db *badger.DB) XidMapOptions {
 }
 
 func TestXidmap(t *testing.T) {
-	conn, err := x.SetupConnection(testutil.SockAddrZero, nil, false)
+	conn, err := x.SetupConnection(testutil.GetSockAddrZero(), nil, false)
 	require.NoError(t, err)
 	require.NotNil(t, conn)
 
@@ -108,7 +108,7 @@ func TestXidmapMemory(t *testing.T) {
 		}
 	}()
 
-	conn, err := x.SetupConnection(testutil.SockAddrZero, nil, false)
+	conn, err := x.SetupConnection(testutil.GetSockAddrZero(), nil, false)
 	require.NoError(t, err)
 	require.NotNil(t, conn)
 
@@ -154,7 +154,7 @@ func TestXidmapMemory(t *testing.T) {
 // BenchmarkXidmapReadsRandom-16		428ns ± 2%
 
 func BenchmarkXidmapWrites(b *testing.B) {
-	conn, err := x.SetupConnection(testutil.SockAddrZero, nil, false)
+	conn, err := x.SetupConnection(testutil.GetSockAddrZero(), nil, false)
 	if err != nil {
 		b.Fatalf("Error setting up connection: %s", err.Error())
 	}
@@ -173,7 +173,7 @@ func BenchmarkXidmapWrites(b *testing.B) {
 }
 
 func BenchmarkXidmapWritesRandom(b *testing.B) {
-	conn, err := x.SetupConnection(testutil.SockAddrZero, nil, false)
+	conn, err := x.SetupConnection(testutil.GetSockAddrZero(), nil, false)
 	if err != nil {
 		b.Fatalf("Error setting up connection: %s", err.Error())
 	}
@@ -194,7 +194,7 @@ func BenchmarkXidmapWritesRandom(b *testing.B) {
 }
 
 func BenchmarkXidmapReads(b *testing.B) {
-	conn, err := x.SetupConnection(testutil.SockAddrZero, nil, false)
+	conn, err := x.SetupConnection(testutil.GetSockAddrZero(), nil, false)
 	if err != nil {
 		b.Fatalf("Error setting up connection: %s", err.Error())
 	}
@@ -216,7 +216,7 @@ func BenchmarkXidmapReads(b *testing.B) {
 }
 
 func BenchmarkXidmapReadsRandom(b *testing.B) {
-	conn, err := x.SetupConnection(testutil.SockAddrZero, nil, false)
+	conn, err := x.SetupConnection(testutil.GetSockAddrZero(), nil, false)
 	if err != nil {
 		b.Fatalf("Error setting up connection: %s", err.Error())
 	}


### PR DESCRIPTION
**Description**

This PR significantly improves performance of "t"-based testing in Dgraph

1. Removes Docker container address resolution from the testutil init() function (any package that imports would block waiting for container addresses that weren't established yet). Instead, the PR introduces a lazy-loading concept that sync.Once's the address resolution. This saves about 20 seconds per test invocation from `t`
2. Parallel-izes the resolution of expected container addresses
3. Parallel-izes the health and login flows
4. Suppresses health-check and login warnings until after a reasonable threshold of failures (these checks constantly pollute the logs)
5. On non-Linux system, informs the user about DGRAPH_BINARY settings that can let tests proceed.
6. Upgrades the warp runner for the core tests to the 16x instance (core tests are the most comprehensive tests)

In general (on my M4) many tests improve time to complete by a factor of 3.

**Checklist**

- [x] Code compiles correctly and linting passes locally
