### PR TITLE
fix(core): prevent timer/ticker leaks; use unsafe.Add for pointer arithmetic

### DIFF
--- a/contrib/jepsen/main.go
+++ b/contrib/jepsen/main.go
@@ -238,15 +238,18 @@ func jepsenServe() error {
 		// command to finish.
 		_ = cmd.Start()
 		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+
+		timeout := time.NewTimer(5 * time.Minute)
+		defer timeout.Stop()
 		for {
 			select {
-			case <-time.After(5 * time.Minute):
+			case <-timeout.C:
 				wg.Done()
 				errCh <- errors.New("lein run serve couldn't run after 5 minutes")
 				return
 			case <-ticker.C:
 				if err := checkServing(); err == nil {
-					ticker.Stop()
 					wg.Done()
 					errCh <- nil
 					return

--- a/dgraph/cmd/zero/zero.go
+++ b/dgraph/cmd/zero/zero.go
@@ -106,8 +106,11 @@ func (s *Server) periodicallyPostTelemetry() {
 
 	glog.Infof("Starting telemetry data collection for zero...")
 
+	ticker := time.NewTicker(6 * time.Hour)
+	defer ticker.Stop()
+
 	var lastPostedAt time.Time
-	for ; true; <-time.Tick(time.Hour * 6) {
+	for range ticker.C {
 		if !s.Node.AmLeader() {
 			continue
 		}

--- a/posting/size.go
+++ b/posting/size.go
@@ -53,9 +53,8 @@ func (l *List) DeepSize() uint64 {
 		hmap := reflect.ValueOf(l.mutationMap)
 		// Note: this will fail if the -race detector flag is used with go tools (test, run),
 		// see: https://github.com/golang/go/issues/48501
-		numBuckets := int(math.Pow(2, float64((*(*uint8)(
-			unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
-		numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
+		numBuckets := int(math.Pow(2, float64(*(*uint8)(unsafe.Add(unsafe.Pointer(hmap.Pointer()), 9)))))
+		numOldBuckets := *(*uint16)(unsafe.Add(unsafe.Pointer(hmap.Pointer()), 10))
 		size += uint64(numOldBuckets * sizeOfBucket)
 		if l.mutationMap.len() > 0 || numBuckets > 1 {
 			size += uint64(numBuckets * sizeOfBucket)

--- a/x/x.go
+++ b/x/x.go
@@ -1227,6 +1227,7 @@ func StoreSync(db DB, closer *z.Closer) {
 	// We technically don't need to call this due to mmap being able to survive process crashes.
 	// But, once a minute is infrequent enough that we won't lose any performance due to this.
 	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:


### PR DESCRIPTION
**Description**

This PR improves runtime safety and resource handling:

- Timer: replaced time.After(...) with time.NewTimer(...) and ensured timer.Stop() is always called to avoid hidden leaks in loops.
- Ticker: added ticker.Stop() and refactored time.Tick(...) usage to use time.NewTicker for proper lifecycle management.
- Unsafe pointer: switched from unsafe.Pointer + uintptr(offset) to unsafe.Add(...) for clearer and more consistent pointer arithmetic.

These changes make timer/ticker usage safer in long-running goroutines and align pointer operations with modern Go practices.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [ ] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to
      this PR
- [ ] Tests added for new functionality, or regression tests for bug fixes added as applicable

