### PR TITLE
fix(core): use deep copy for committedUids to prevent mutation corruption

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -1010,7 +1010,7 @@ func (l *List) setMutationAfterCommit(startTs, commitTs uint64, pl *pb.PostingLi
 	if refresh {
 		newMap := make(map[uint64]*pb.Posting, len(l.mutationMap.committedUids))
 		for uid, post := range l.mutationMap.committedUids {
-			newMap[uid] = post
+			newMap[uid] = proto.Clone(post).(*pb.Posting)
 		}
 		l.mutationMap.committedUids = newMap
 	}


### PR DESCRIPTION
**Description**

This PR addresses a stability issue in mutation handling:

- Replaced shallow copy of committedUids with deep copy to prevent external
  modifications from corrupting committed state.

These changes make committedUids safer and preserve correctness during refresh.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [ ] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to
      this PR
- [ ] Tests added for new functionality, or regression tests for bug fixes added as applicable
