### PR TITLE
chore(tests): Future-proof whitelist against Docker network changes

### DIFF
--- a/compose/compose.go
+++ b/compose/compose.go
@@ -307,7 +307,7 @@ func getAlpha(idx int, raft string) service {
 		svc.Command += fmt.Sprintf(" --vmodule=%s", opts.Vmodule)
 	}
 	if opts.WhiteList {
-		svc.Command += ` --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"`
+		svc.Command += ` --security "whitelist=0.0.0.0/0;"`
 	}
 	if opts.Acl {
 		svc.Command += ` --acl "secret-file=/secret/hmac;"`

--- a/dgraph/cmd/alpha/mutations_mode/docker-compose.yml
+++ b/dgraph/cmd/alpha/mutations_mode/docker-compose.yml
@@ -18,8 +18,8 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha1:7080
-      --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --limit "mutations=disallow;"
+      --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --security "whitelist=0.0.0.0/0;"
+      --limit "mutations=disallow;"
   alpha2:
     image: dgraph/dgraph:local
     working_dir: /data/alpha2
@@ -35,8 +35,8 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha2:7080
-      --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --limit "mutations=strict;"
+      --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --security "whitelist=0.0.0.0/0;"
+      --limit "mutations=strict;"
   alpha3:
     image: dgraph/dgraph:local
     working_dir: /data/alpha3
@@ -52,8 +52,8 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha3:7080
-      --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --limit "mutations=strict;"
+      --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --security "whitelist=0.0.0.0/0;"
+      --limit "mutations=strict;"
   zero1:
     image: dgraph/dgraph:local
     working_dir: /data/zero1

--- a/dgraph/docker-compose.yml
+++ b/dgraph/docker-compose.yml
@@ -85,8 +85,7 @@ services:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --telemetry "reports=false;" --encryption
       "key-file=/dgraph-enc/enc-key;" --my=alpha1:7080 --zero=zero1:5080,zero2:5080,zero3:5080
       --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --acl
-      "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
+      "whitelist=0.0.0.0/0;" --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
   alpha2:
     image: dgraph/dgraph:local
@@ -115,8 +114,7 @@ services:
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --encryption "key-file=/dgraph-enc/enc-key;"
       --my=alpha2:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block
-      --block_rate 10 --logtostderr -v=2 --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --acl
+      --block_rate 10 --logtostderr -v=2 --security "whitelist=0.0.0.0/0;" --acl
       "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
   alpha3:
@@ -146,8 +144,7 @@ services:
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --encryption "key-file=/dgraph-enc/enc-key;"
       --my=alpha3:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block
-      --block_rate 10 --logtostderr -v=2 --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --acl
+      --block_rate 10 --logtostderr -v=2 --security "whitelist=0.0.0.0/0;" --acl
       "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
   alpha4:
@@ -177,8 +174,7 @@ services:
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --encryption "key-file=/dgraph-enc/enc-key;"
       --my=alpha4:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block
-      --block_rate 10 --logtostderr -v=2 --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --acl
+      --block_rate 10 --logtostderr -v=2 --security "whitelist=0.0.0.0/0;" --acl
       "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
   alpha5:
@@ -208,8 +204,7 @@ services:
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --encryption "key-file=/dgraph-enc/enc-key;"
       --my=alpha5:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block
-      --block_rate 10 --logtostderr -v=2 --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --acl
+      --block_rate 10 --logtostderr -v=2 --security "whitelist=0.0.0.0/0;" --acl
       "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
   alpha6:
@@ -239,8 +234,7 @@ services:
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --encryption "key-file=/dgraph-enc/enc-key;"
       --my=alpha6:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block
-      --block_rate 10 --logtostderr -v=2 --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --acl
+      --block_rate 10 --logtostderr -v=2 --security "whitelist=0.0.0.0/0;" --acl
       "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
   minio:

--- a/dgraphtest/dgraph.go
+++ b/dgraphtest/dgraph.go
@@ -235,10 +235,9 @@ func (a *alpha) cmd(c *LocalCluster) []string {
 		"--bindall", "--logtostderr", fmt.Sprintf("-v=%d", c.conf.verbosity)}
 
 	if c.lowerThanV21 {
-		acmd = append(acmd, `--whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16`, "--telemetry=false")
+		acmd = append(acmd, `--whitelist=0.0.0.0/0`, "--telemetry=false")
 	} else {
-		acmd = append(acmd, `--security=whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16`,
-			"--telemetry=reports=false;")
+		acmd = append(acmd, `--security=whitelist=0.0.0.0/0`, "--telemetry=reports=false;")
 	}
 
 	if c.conf.lambdaURL != "" {

--- a/graphql/e2e/admin_auth/poorman_auth/docker-compose.yml
+++ b/graphql/e2e/admin_auth/poorman_auth/docker-compose.yml
@@ -34,5 +34,5 @@ services:
       service: alpha1
     command:
       /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --expose_trace
-      --profile_mode block --block_rate 10 --logtostderr -v=2 --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16; token=itIsSecret;" --trace "ratio=1.0;"
+      --profile_mode block --block_rate 10 --logtostderr -v=2 --security "whitelist=0.0.0.0/0;
+      token=itIsSecret;" --trace "ratio=1.0;"

--- a/graphql/e2e/admin_auth/poorman_auth_with_acl/docker-compose.yml
+++ b/graphql/e2e/admin_auth/poorman_auth_with_acl/docker-compose.yml
@@ -38,6 +38,6 @@ services:
       service: alpha1
     command:
       /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --expose_trace
-      --profile_mode block --block_rate 10 --logtostderr -v=2 --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16; token=itIsSecret;" --acl
-      "secret-file=/dgraph-acl/hmac-secret; access-ttl=3s;" --trace "ratio=1.0;"
+      --profile_mode block --block_rate 10 --logtostderr -v=2 --security "whitelist=0.0.0.0/0;
+      token=itIsSecret;" --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=3s;" --trace
+      "ratio=1.0;"

--- a/graphql/e2e/auth/debug_off/docker-compose.yml
+++ b/graphql/e2e/auth/debug_off/docker-compose.yml
@@ -34,5 +34,5 @@ services:
       service: alpha1
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --zero=zero1:5080 --expose_trace --profile_mode block
-      --block_rate 10 --logtostderr -v=3 --my=alpha1:7080 --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --trace "ratio=1.0;"
+      --block_rate 10 --logtostderr -v=3 --my=alpha1:7080 --security "whitelist=0.0.0.0/0;" --trace
+      "ratio=1.0;"

--- a/graphql/e2e/auth/docker-compose.yml
+++ b/graphql/e2e/auth/docker-compose.yml
@@ -34,6 +34,5 @@ services:
       service: alpha1
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --zero=zero1:5080 --expose_trace --profile_mode block
-      --block_rate 10 --logtostderr -v=3 --my=alpha1:7080 --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --graphql "debug=true;" --trace
-      "ratio=1.0;"
+      --block_rate 10 --logtostderr -v=3 --my=alpha1:7080 --security "whitelist=0.0.0.0/0;"
+      --graphql "debug=true;" --trace "ratio=1.0;"

--- a/graphql/e2e/auth_closed_by_default/docker-compose.yml
+++ b/graphql/e2e/auth_closed_by_default/docker-compose.yml
@@ -34,6 +34,5 @@ services:
       service: alpha1
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --zero=zero1:5080 --expose_trace --profile_mode block
-      --block_rate 10 --logtostderr -v=3 --my=alpha1:7080 --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --graphql "debug=true;" --trace
-      "ratio=1.0;"
+      --block_rate 10 --logtostderr -v=3 --my=alpha1:7080 --security "whitelist=0.0.0.0/0;"
+      --graphql "debug=true;" --trace "ratio=1.0;"

--- a/graphql/e2e/custom_logic/docker-compose.yml
+++ b/graphql/e2e/custom_logic/docker-compose.yml
@@ -17,7 +17,7 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
-      --raft="idx=1;" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      --raft="idx=1;" --security "whitelist=0.0.0.0/0;"
   zero1:
     image: dgraph/dgraph:local
     working_dir: /data/zero1

--- a/graphql/e2e/directives/docker-compose.yml
+++ b/graphql/e2e/directives/docker-compose.yml
@@ -34,9 +34,8 @@ services:
       service: alpha1
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --zero=zero1:5080 --expose_trace --profile_mode block
-      --block_rate 10 --logtostderr -v=2 --my=alpha1:7080 --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --graphql
-      "lambda-url=http://lambda:8686/graphql-worker; debug=true;" --trace "ratio=1.0;"
+      --block_rate 10 --logtostderr -v=2 --my=alpha1:7080 --security "whitelist=0.0.0.0/0;"
+      --graphql "lambda-url=http://lambda:8686/graphql-worker; debug=true;" --trace "ratio=1.0;"
 
   lambda:
     image: dgraph/dgraph-lambda:latest

--- a/graphql/e2e/multi_tenancy/docker-compose.yml
+++ b/graphql/e2e/multi_tenancy/docker-compose.yml
@@ -21,8 +21,8 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
-      --raft "idx=1;" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --acl
-      "secret-file=/dgraph-acl/hmac-secret; access-ttl=3000s;"
+      --raft "idx=1;" --security "whitelist=0.0.0.0/0;" --acl "secret-file=/dgraph-acl/hmac-secret;
+      access-ttl=3000s;"
   alpha2:
     image: dgraph/dgraph:local
     working_dir: /data/alpha2
@@ -44,8 +44,8 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2
-      --raft "idx=2;" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --acl
-      "secret-file=/dgraph-acl/hmac-secret; access-ttl=3000s;"
+      --raft "idx=2;" --security "whitelist=0.0.0.0/0;" --acl "secret-file=/dgraph-acl/hmac-secret;
+      access-ttl=3000s;"
   alpha3:
     image: dgraph/dgraph:local
     working_dir: /data/alpha3
@@ -67,8 +67,8 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2
-      --raft "idx=3;" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --acl
-      "secret-file=/dgraph-acl/hmac-secret; access-ttl=3000s;"
+      --raft "idx=3;" --security "whitelist=0.0.0.0/0;" --acl "secret-file=/dgraph-acl/hmac-secret;
+      access-ttl=3000s;"
   zero1:
     image: dgraph/dgraph:local
     working_dir: /data/zero1

--- a/graphql/e2e/normal/docker-compose.yml
+++ b/graphql/e2e/normal/docker-compose.yml
@@ -34,9 +34,8 @@ services:
       service: alpha1
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --zero=zero1:5080 --expose_trace --profile_mode block
-      --block_rate 10 --logtostderr -v=2 --my=alpha1:7080 --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --graphql
-      "lambda-url=http://lambda:8686/graphql-worker; debug=true;" --trace "ratio=1.0;"
+      --block_rate 10 --logtostderr -v=2 --my=alpha1:7080 --security "whitelist=0.0.0.0/0;"
+      --graphql "lambda-url=http://lambda:8686/graphql-worker; debug=true;" --trace "ratio=1.0;"
 
   lambda:
     image: dgraph/dgraph-lambda:latest

--- a/graphql/e2e/schema/docker-compose.yml
+++ b/graphql/e2e/schema/docker-compose.yml
@@ -21,7 +21,7 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
-      --raft "idx=1;" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      --raft "idx=1;" --security "whitelist=0.0.0.0/0;"
   alpha2:
     image: dgraph/dgraph:local
     working_dir: /data/alpha2
@@ -43,7 +43,7 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2
-      --raft "idx=2;" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      --raft "idx=2;" --security "whitelist=0.0.0.0/0;"
   alpha3:
     image: dgraph/dgraph:local
     working_dir: /data/alpha3
@@ -65,7 +65,7 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2
-      --raft "idx=3;" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      --raft "idx=3;" --security "whitelist=0.0.0.0/0;"
   zero1:
     image: dgraph/dgraph:local
     working_dir: /data/zero1

--- a/graphql/e2e/subscription/docker-compose.yml
+++ b/graphql/e2e/subscription/docker-compose.yml
@@ -17,7 +17,7 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
-      --raft="idx=1;" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      --raft="idx=1;" --security "whitelist=0.0.0.0/0;"
   alpha2:
     image: dgraph/dgraph:local
     working_dir: /data/alpha2
@@ -35,7 +35,7 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2
-      --raft="idx=2;" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      --raft="idx=2;" --security "whitelist=0.0.0.0/0;"
   alpha3:
     image: dgraph/dgraph:local
     working_dir: /data/alpha3
@@ -53,7 +53,7 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2
-      --raft="idx=3;" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      --raft="idx=3;" --security "whitelist=0.0.0.0/0;"
   zero1:
     image: dgraph/dgraph:local
     working_dir: /data/zero1

--- a/graphql/testdata/custom_bench/profiling/docker-compose.yml
+++ b/graphql/testdata/custom_bench/profiling/docker-compose.yml
@@ -26,8 +26,7 @@ services:
         read_only: false
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha -o 100 --my=alpha1:7180 --lru_mb=1024
-      --zero=zero1:5180 --logtostderr -v=2 --raft="idx=1;" --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      --zero=zero1:5180 --logtostderr -v=2 --raft="idx=1;" --security "whitelist=0.0.0.0/0;"
   zero1:
     image: dgraph/dgraph:local
     container_name: zero1

--- a/systest/1million/alpha.yml
+++ b/systest/1million/alpha.yml
@@ -19,4 +19,4 @@ services:
         read_only: false
     command:
       /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 -p=/posting --logtostderr -v=2
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      --security "whitelist=0.0.0.0/0;"

--- a/systest/21million/bulk/alpha.yml
+++ b/systest/21million/bulk/alpha.yml
@@ -19,4 +19,4 @@ services:
         read_only: false
     command:
       /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 -p=/posting --logtostderr -v=2
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      --security "whitelist=0.0.0.0/0;"

--- a/systest/acl/restore/docker-compose.yml
+++ b/systest/acl/restore/docker-compose.yml
@@ -23,8 +23,7 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
-      --raft "idx=1; group=1" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --acl
-      "secret-file=/secret/hmac;"
+      --raft "idx=1; group=1" --security "whitelist=0.0.0.0/0;" --acl "secret-file=/secret/hmac;"
     deploy:
       resources:
         limits:

--- a/systest/audit/docker-compose.yml
+++ b/systest/audit/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --raft="idx=1;group=1" --my=alpha1:7080
       --zero=zero1:5080 --logtostderr --audit "output=/audit_dir;" -v=2 --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      "whitelist=0.0.0.0/0;"
   zero1:
     image: dgraph/dgraph:local
     working_dir: /data/zero1

--- a/systest/audit_encrypted/docker-compose.yml
+++ b/systest/audit_encrypted/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --raft="idx=1;group=1" --my=alpha1:7080
       --zero=zero1:5080 --logtostderr --audit "output=/audit_dir;encrypt-file=/dgraph-enc/enc-key"
-      -v=2 --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      -v=2 --security "whitelist=0.0.0.0/0;"
   zero1:
     image: dgraph/dgraph:local
     working_dir: /data/zero1

--- a/systest/backup/advanced-scenarios/127-Namespace/docker-compose.yml
+++ b/systest/backup/advanced-scenarios/127-Namespace/docker-compose.yml
@@ -25,8 +25,7 @@ services:
 
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
-      --raft "idx=1; group=1;" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --acl
-      "secret-file=/secret/hmac;"
+      --raft "idx=1; group=1;" --security "whitelist=0.0.0.0/0;" --acl "secret-file=/secret/hmac;"
 
   zero1:
     image: dgraph/dgraph:local
@@ -68,8 +67,7 @@ services:
       - data-volume:/data/backups/
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha2:7080 --zero=zero2:5080 --logtostderr -v=2
-      --raft "idx=1; group=1;" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --acl
-      "secret-file=/secret/hmac;"
+      --raft "idx=1; group=1;" --security "whitelist=0.0.0.0/0;" --acl "secret-file=/secret/hmac;"
 
   zero2:
     image: dgraph/dgraph:local

--- a/systest/backup/advanced-scenarios/acl-nonAcl/docker-compose.yml
+++ b/systest/backup/advanced-scenarios/acl-nonAcl/docker-compose.yml
@@ -26,8 +26,7 @@ services:
       - data-volume:/data/backups/
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
-      --raft "idx=1; group=1;" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --acl
-      "secret-file=/secret/hmac;"
+      --raft "idx=1; group=1;" --security "whitelist=0.0.0.0/0;" --acl "secret-file=/secret/hmac;"
 
   zero1:
     image: dgraph/dgraph:local
@@ -66,7 +65,7 @@ services:
       - data-volume:/data/backups/
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha2:7080 --zero=zero2:5080 --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      "whitelist=0.0.0.0/0;"
 
   zero2:
     image: dgraph/dgraph:local
@@ -110,8 +109,7 @@ services:
       - data-volume:/data/backups/
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha3:7080 --zero=zero3:5080 --logtostderr -v=2
-      --raft "idx=1; group=1;" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --acl
-      "secret-file=/secret/hmac;"
+      --raft "idx=1; group=1;" --security "whitelist=0.0.0.0/0;" --acl "secret-file=/secret/hmac;"
 
   zero3:
     image: dgraph/dgraph:local
@@ -150,7 +148,7 @@ services:
       - data-volume:/data/backups/
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha4:7080 --zero=zero4:5080 --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      "whitelist=0.0.0.0/0;"
 
   zero4:
     image: dgraph/dgraph:local

--- a/systest/backup/advanced-scenarios/deleted-namespace/docker-compose.yml
+++ b/systest/backup/advanced-scenarios/deleted-namespace/docker-compose.yml
@@ -24,8 +24,7 @@ services:
       - data-volume:/data/backups/
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
-      --raft "idx=1; group=1;" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --acl
-      "secret-file=/secret/hmac;"
+      --raft "idx=1; group=1;" --security "whitelist=0.0.0.0/0;" --acl "secret-file=/secret/hmac;"
 
   zero1:
     image: dgraph/dgraph:local
@@ -67,8 +66,7 @@ services:
       - data-volume:/data/backups/
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha2:7080 --zero=zero2:5080 --logtostderr -v=2
-      --raft "idx=1; group=1;" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --acl
-      "secret-file=/secret/hmac;"
+      --raft "idx=1; group=1;" --security "whitelist=0.0.0.0/0;" --acl "secret-file=/secret/hmac;"
 
   zero2:
     image: dgraph/dgraph:local

--- a/systest/backup/encryption/docker-compose.yml
+++ b/systest/backup/encryption/docker-compose.yml
@@ -25,9 +25,9 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
-      --encryption="key-file=/dgraph-enc/enc-key;" --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --tls "ca-cert=/dgraph-tls/ca.crt;
-      server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true;
+      --encryption="key-file=/dgraph-enc/enc-key;" --security "whitelist=0.0.0.0/0;" --tls
+      "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt;
+      server-key=/dgraph-tls/node.key; internal-port=true;
       client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   alpha2:
     image: dgraph/dgraph:local
@@ -54,9 +54,9 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2
-      --encryption="key-file=/dgraph-enc/enc-key;" --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --tls "ca-cert=/dgraph-tls/ca.crt;
-      server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true;
+      --encryption="key-file=/dgraph-enc/enc-key;" --security "whitelist=0.0.0.0/0;" --tls
+      "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt;
+      server-key=/dgraph-tls/node.key; internal-port=true;
       client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
   alpha3:
     image: dgraph/dgraph:local
@@ -83,9 +83,9 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2
-      --encryption="key-file=/dgraph-enc/enc-key;" --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --tls "ca-cert=/dgraph-tls/ca.crt;
-      server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true;
+      --encryption="key-file=/dgraph-enc/enc-key;" --security "whitelist=0.0.0.0/0;" --tls
+      "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt;
+      server-key=/dgraph-tls/node.key; internal-port=true;
       client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
   zero1:
     image: dgraph/dgraph:local

--- a/systest/backup/filesystem/docker-compose.yml
+++ b/systest/backup/filesystem/docker-compose.yml
@@ -25,9 +25,8 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --tls
-      "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt;
-      server-key=/dgraph-tls/node.key; internal-port=true;
+      --security "whitelist=0.0.0.0/0;" --tls "ca-cert=/dgraph-tls/ca.crt;
+      server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true;
       client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   alpha2:
     image: dgraph/dgraph:local
@@ -52,9 +51,8 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --tls
-      "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt;
-      server-key=/dgraph-tls/node.key; internal-port=true;
+      --security "whitelist=0.0.0.0/0;" --tls "ca-cert=/dgraph-tls/ca.crt;
+      server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true;
       client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
   alpha3:
     image: dgraph/dgraph:local
@@ -79,9 +77,8 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --tls
-      "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt;
-      server-key=/dgraph-tls/node.key; internal-port=true;
+      --security "whitelist=0.0.0.0/0;" --tls "ca-cert=/dgraph-tls/ca.crt;
+      server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true;
       client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
   zero1:
     image: dgraph/dgraph:local

--- a/systest/backup/minio-large/docker-compose.yml
+++ b/systest/backup/minio-large/docker-compose.yml
@@ -23,9 +23,8 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --tls
-      "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt;
-      server-key=/dgraph-tls/node.key; internal-port=true;
+      --security "whitelist=0.0.0.0/0;" --tls "ca-cert=/dgraph-tls/ca.crt;
+      server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true;
       client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   alpha2:
     image: dgraph/dgraph:local
@@ -48,9 +47,8 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --tls
-      "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt;
-      server-key=/dgraph-tls/node.key; internal-port=true;
+      --security "whitelist=0.0.0.0/0;" --tls "ca-cert=/dgraph-tls/ca.crt;
+      server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true;
       client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
   alpha3:
     image: dgraph/dgraph:local
@@ -73,9 +71,8 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --tls
-      "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt;
-      server-key=/dgraph-tls/node.key; internal-port=true;
+      --security "whitelist=0.0.0.0/0;" --tls "ca-cert=/dgraph-tls/ca.crt;
+      server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true;
       client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
   minio:
     image: minio/minio:${MINIO_IMAGE_ARCH:-RELEASE.2020-11-13T20-10-18Z}

--- a/systest/backup/minio/docker-compose.yml
+++ b/systest/backup/minio/docker-compose.yml
@@ -23,8 +23,8 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
-      --cache "size-mb=500;" -v=2 --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
-      --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt;
+      --cache "size-mb=500;" -v=2 --security "whitelist=0.0.0.0/0;" --tls
+      "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt;
       server-key=/dgraph-tls/node.key; internal-port=true;
       client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   alpha2:
@@ -48,8 +48,8 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr
-      --cache "size-mb=500;" -v=2 --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
-      --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt;
+      --cache "size-mb=500;" -v=2 --security "whitelist=0.0.0.0/0;" --tls
+      "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt;
       server-key=/dgraph-tls/node.key; internal-port=true;
       client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
   alpha3:
@@ -73,8 +73,8 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr
-      --cache "size-mb=500;" -v=2 --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
-      --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt;
+      --cache "size-mb=500;" -v=2 --security "whitelist=0.0.0.0/0;" --tls
+      "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt;
       server-key=/dgraph-tls/node.key; internal-port=true;
       client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
   zero1:

--- a/systest/backup/multi-tenancy/docker-compose.yml
+++ b/systest/backup/multi-tenancy/docker-compose.yml
@@ -25,8 +25,7 @@ services:
         read_only: false
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
-      --raft "idx=1; group=1;" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --acl
-      "secret-file=/secret/hmac;"
+      --raft "idx=1; group=1;" --security "whitelist=0.0.0.0/0;" --acl "secret-file=/secret/hmac;"
   alpha2:
     image: dgraph/dgraph:local
     working_dir: /data/alpha2
@@ -50,8 +49,7 @@ services:
         read_only: false
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2
-      --raft "idx=2; group=2;" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --acl
-      "secret-file=/secret/hmac;"
+      --raft "idx=2; group=2;" --security "whitelist=0.0.0.0/0;" --acl "secret-file=/secret/hmac;"
   alpha3:
     image: dgraph/dgraph:local
     working_dir: /data/alpha3
@@ -75,8 +73,7 @@ services:
         read_only: false
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2
-      --raft "idx=3; group=3;" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --acl
-      "secret-file=/secret/hmac;"
+      --raft "idx=3; group=3;" --security "whitelist=0.0.0.0/0;" --acl "secret-file=/secret/hmac;"
   zero1:
     image: dgraph/dgraph:local
     working_dir: /data/zero1

--- a/systest/backup/nfs-backup/docker-compose.yml
+++ b/systest/backup/nfs-backup/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - -c
       - |
         mount -v -o vers=4,loud nfs:/ /mnt 2>&1 &
-        /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha1_backup_clust_ha:7080  --zero=zero1_backup_clust_ha:5080,zero2_backup_clust_ha:5080,zero3_backup_clust_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+        /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha1_backup_clust_ha:7080  --zero=zero1_backup_clust_ha:5080,zero2_backup_clust_ha:5080,zero3_backup_clust_ha:5080 --logtostderr -v=2  --security "whitelist=0.0.0.0/0;"
 
   alpha2_backup_clust_ha:
     image: dgraph-nfs-client:local
@@ -47,7 +47,7 @@ services:
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha
       --my=alpha2_backup_clust_ha:7080  --zero=zero1_backup_clust_ha:5080,zero2_backup_clust_ha:5080,zero3_backup_clust_ha:5080
-      --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      --logtostderr -v=2  --security "whitelist=0.0.0.0/0;"
 
   alpha3_backup_clust_ha:
     image: dgraph-nfs-client:local
@@ -69,7 +69,7 @@ services:
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha
       --my=alpha3_backup_clust_ha:7080  --zero=zero1_backup_clust_ha:5080,zero2_backup_clust_ha:5080,zero3_backup_clust_ha:5080
-      --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      --logtostderr -v=2  --security "whitelist=0.0.0.0/0;"
 
   zero1_backup_clust_ha:
     image: dgraph-nfs-client:local
@@ -158,7 +158,7 @@ services:
       - -c
       - |
         mount -v -o vers=4,loud nfs:/ /mnt 2>&1 &
-        /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha4_restore_clust_ha:7080  --zero=zero4_restore_clust_ha:5080,zero5_restore_clust_ha:5080,zero6_restore_clust_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+        /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha4_restore_clust_ha:7080  --zero=zero4_restore_clust_ha:5080,zero5_restore_clust_ha:5080,zero6_restore_clust_ha:5080 --logtostderr -v=2  --security "whitelist=0.0.0.0/0;"
 
   alpha5_restore_clust_ha:
     image: dgraph-nfs-client:local
@@ -180,7 +180,7 @@ services:
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha
       --my=alpha5_restore_clust_ha:7080  --zero=zero4_restore_clust_ha:5080,zero5_restore_clust_ha:5080,zero6_restore_clust_ha:5080
-      --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      --logtostderr -v=2  --security "whitelist=0.0.0.0/0;"
 
   alpha6_restore_clust_ha:
     image: dgraph-nfs-client:local
@@ -202,7 +202,7 @@ services:
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha
       --my=alpha6_restore_clust_ha:7080  --zero=zero4_restore_clust_ha:5080,zero5_restore_clust_ha:5080,zero6_restore_clust_ha:5080
-      --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      --logtostderr -v=2  --security "whitelist=0.0.0.0/0;"
 
   zero4_restore_clust_ha:
     image: dgraph-nfs-client:local
@@ -312,7 +312,7 @@ services:
       - -c
       - |
         mount -v -o vers=4,loud nfs:/ /mnt 2>&1 &
-        /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha7_backup_clust_non_ha:7080  --zero=zero7_backup_clust_non_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+        /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha7_backup_clust_non_ha:7080  --zero=zero7_backup_clust_non_ha:5080 --logtostderr -v=2  --security "whitelist=0.0.0.0/0;"
 
   #non HA restore cluster
   zero8_restore_clust_non_ha:
@@ -359,7 +359,7 @@ services:
       - -c
       - |
         mount -v -o vers=4,loud nfs:/ /mnt 2>&1 &
-        /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha8_restore_clust_non_ha:7080  --zero=zero8_restore_clust_non_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+        /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha8_restore_clust_non_ha:7080  --zero=zero8_restore_clust_non_ha:5080 --logtostderr -v=2  --security "whitelist=0.0.0.0/0;"
 
   nfs:
     image: itsthenetwork/nfs-server-alpine:${NFS_SERVER_IMAGE_ARCH:-12}

--- a/systest/bgindex/docker-compose.yml
+++ b/systest/bgindex/docker-compose.yml
@@ -21,7 +21,7 @@ services:
         read_only: true
     command:
       /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --acl "secret-file=/secret/hmac;"
+      "whitelist=0.0.0.0/0;" --acl "secret-file=/secret/hmac;"
   zero1:
     image: dgraph/dgraph:local
     working_dir: /data/zero1

--- a/systest/bulk_live/live/docker-compose.yml
+++ b/systest/bulk_live/live/docker-compose.yml
@@ -17,7 +17,7 @@ services:
         read_only: true
     command:
       /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 --raft='idx=1;
-      group=1;' --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      group=1;' --security "whitelist=0.0.0.0/0;"
     deploy:
       resources:
         limits:

--- a/systest/cdc/docker-compose.yml
+++ b/systest/cdc/docker-compose.yml
@@ -18,7 +18,7 @@ services:
         target: /cdc
     command:
       /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr --cdc
-      "file=/cdc;" -v=2 --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      "file=/cdc;" -v=2 --security "whitelist=0.0.0.0/0;"
   zero1:
     image: dgraph/dgraph:local
     working_dir: /data/zero1

--- a/systest/cloud/docker-compose.yml
+++ b/systest/cloud/docker-compose.yml
@@ -40,9 +40,8 @@ services:
       service: alpha
     command:
       /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace
-      --profile_mode block --block_rate 10 --logtostderr -v=2 --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --acl
-      "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;" --limit "shared-instance=true"
+      --profile_mode block --block_rate 10 --logtostderr -v=2 --security "whitelist=0.0.0.0/0;"
+      --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;" --limit "shared-instance=true"
 
   minio:
     image: minio/minio:latest

--- a/systest/export/docker-compose.yml
+++ b/systest/export/docker-compose.yml
@@ -23,7 +23,7 @@ services:
         read_only: false
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      --security "whitelist=0.0.0.0/0;"
   alpha2:
     image: dgraph/dgraph:local
     working_dir: /data/alpha2
@@ -45,7 +45,7 @@ services:
         read_only: false
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      --security "whitelist=0.0.0.0/0;"
   alpha3:
     image: dgraph/dgraph:local
     working_dir: /data/alpha3
@@ -67,7 +67,7 @@ services:
         read_only: false
     command:
       /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      --security "whitelist=0.0.0.0/0;"
   minio:
     image: minio/minio:${MINIO_IMAGE_ARCH:-RELEASE.2020-11-13T20-10-18Z}
     env_file:

--- a/systest/group-delete/docker-compose.yml
+++ b/systest/group-delete/docker-compose.yml
@@ -17,7 +17,7 @@ services:
         read_only: true
     command:
       /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
-      --raft "group=1" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      --raft "group=1" --security "whitelist=0.0.0.0/0;"
   alpha2:
     image: dgraph/dgraph:local
     working_dir: /data/alpha2
@@ -33,7 +33,7 @@ services:
         read_only: true
     command:
       /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2
-      --raft "group=2" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      --raft "group=2" --security "whitelist=0.0.0.0/0;"
   alpha3:
     image: dgraph/dgraph:local
     working_dir: /data/alpha3
@@ -49,7 +49,7 @@ services:
         read_only: true
     command:
       /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2
-      --raft "group=3" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      --raft "group=3" --security "whitelist=0.0.0.0/0;"
   zero1:
     image: dgraph/dgraph:local
     working_dir: /data/zero1

--- a/systest/ldbc/alpha.yml
+++ b/systest/ldbc/alpha.yml
@@ -19,4 +19,4 @@ services:
         read_only: false
     command:
       /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 -p=/posting
-      --logtostderr -v=2 --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      --logtostderr -v=2 --security "whitelist=0.0.0.0/0;"

--- a/systest/loader-benchmark/docker-compose.yml
+++ b/systest/loader-benchmark/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       cluster: test
     command: >
       /gobin/dgraph alpha --my=dg1:7180 --zero=zero1:5180 -o 100 --logtostderr
-                          --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+                          --security "whitelist=0.0.0.0/0;"
 
 volumes:
   data:

--- a/systest/loader/docker-compose.yml
+++ b/systest/loader/docker-compose.yml
@@ -21,9 +21,8 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --tls
-      "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt;
-      server-key=/dgraph-tls/node.key; internal-port=true;
+      --security "whitelist=0.0.0.0/0;" --tls "ca-cert=/dgraph-tls/ca.crt;
+      server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true;
       client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   zero1:
     image: dgraph/dgraph:local

--- a/systest/multi-tenancy/docker-compose.yml
+++ b/systest/multi-tenancy/docker-compose.yml
@@ -43,6 +43,5 @@ services:
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --encryption "key-file=/dgraph-enc/enc-key;"
       --my=alpha1:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block
-      --block_rate 10 --logtostderr -v=2 --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --acl
+      --block_rate 10 --logtostderr -v=2 --security "whitelist=0.0.0.0/0;" --acl
       "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"

--- a/systest/online-restore/docker-compose.yml
+++ b/systest/online-restore/docker-compose.yml
@@ -31,9 +31,9 @@ services:
         read_only: true
     command:
       /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
-      --raft "idx=1;" --encryption "key-file=/data/keys/enc_key;" --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --tls "ca-cert=/dgraph-tls/ca.crt;
-      server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true;
+      --raft "idx=1;" --encryption "key-file=/data/keys/enc_key;" --security "whitelist=0.0.0.0/0;"
+      --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt;
+      server-key=/dgraph-tls/node.key; internal-port=true;
       client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   alpha2:
     image: dgraph/dgraph:local
@@ -68,9 +68,9 @@ services:
         read_only: true
     command:
       /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2
-      --raft "idx=2;" --encryption "key-file=/data/keys/enc_key;" --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --tls "ca-cert=/dgraph-tls/ca.crt;
-      server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true;
+      --raft "idx=2;" --encryption "key-file=/data/keys/enc_key;" --security "whitelist=0.0.0.0/0;"
+      --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt;
+      server-key=/dgraph-tls/node.key; internal-port=true;
       client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
   alpha3:
     image: dgraph/dgraph:local
@@ -105,9 +105,9 @@ services:
         read_only: true
     command:
       /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2
-      --raft "idx=3;" --encryption "key-file=/data/keys/enc_key;" --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --tls "ca-cert=/dgraph-tls/ca.crt;
-      server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true;
+      --raft "idx=3;" --encryption "key-file=/data/keys/enc_key;" --security "whitelist=0.0.0.0/0;"
+      --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt;
+      server-key=/dgraph-tls/node.key; internal-port=true;
       client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
   alpha4:
     image: dgraph/dgraph:local
@@ -142,9 +142,9 @@ services:
         read_only: true
     command:
       /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha4:7080 --zero=zero1:5080 --logtostderr -v=2
-      --raft "idx=4;" --encryption "key-file=/data/keys/enc_key;" --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --tls "ca-cert=/dgraph-tls/ca.crt;
-      server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true;
+      --raft "idx=4;" --encryption "key-file=/data/keys/enc_key;" --security "whitelist=0.0.0.0/0;"
+      --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt;
+      server-key=/dgraph-tls/node.key; internal-port=true;
       client-cert=/dgraph-tls/client.alpha4.crt; client-key=/dgraph-tls/client.alpha4.key;"
   alpha5:
     image: dgraph/dgraph:local
@@ -179,9 +179,9 @@ services:
         read_only: true
     command:
       /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha5:7080 --zero=zero1:5080 --logtostderr -v=2
-      --raft "idx=5;" --encryption "key-file=/data/keys/enc_key;" --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --tls "ca-cert=/dgraph-tls/ca.crt;
-      server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true;
+      --raft "idx=5;" --encryption "key-file=/data/keys/enc_key;" --security "whitelist=0.0.0.0/0;"
+      --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt;
+      server-key=/dgraph-tls/node.key; internal-port=true;
       client-cert=/dgraph-tls/client.alpha5.crt; client-key=/dgraph-tls/client.alpha5.key;"
   alpha6:
     image: dgraph/dgraph:local
@@ -216,9 +216,9 @@ services:
         read_only: true
     command:
       /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha6:7080 --zero=zero1:5080 --logtostderr -v=2
-      --raft "idx=6;" --encryption "key-file=/data/keys/enc_key;" --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --tls "ca-cert=/dgraph-tls/ca.crt;
-      server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true;
+      --raft "idx=6;" --encryption "key-file=/data/keys/enc_key;" --security "whitelist=0.0.0.0/0;"
+      --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt;
+      server-key=/dgraph-tls/node.key; internal-port=true;
       client-cert=/dgraph-tls/client.alpha6.crt; client-key=/dgraph-tls/client.alpha6.key;"
   zero1:
     image: dgraph/dgraph:local

--- a/systest/plugin/docker-compose.yml
+++ b/systest/plugin/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
       --custom_tokenizers=/plugins/0.so,/plugins/1.so,/plugins/2.so,/plugins/3.so -v=2 --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      "whitelist=0.0.0.0/0;"
   zero1:
     image: dgraph/dgraph:local
     working_dir: /data/zero1

--- a/testutil/testaudit/docker-compose.yml
+++ b/testutil/testaudit/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --raft="idx=1;group=1" --my=alpha1:7080
       --zero=zero1:5080 --logtostderr --audit "output=/audit_dir;encrypt-file=/dgraph-enc/enc-key"
-      -v=2 --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      -v=2 --security "whitelist=0.0.0.0/0;"
   zero1:
     image: dgraph/dgraph:local
     working_dir: /data/zero1

--- a/tlstest/acl/docker-compose.yml
+++ b/tlstest/acl/docker-compose.yml
@@ -23,9 +23,9 @@ services:
         read_only: true
     command:
       /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
-      --acl "secret-file=/dgraph-acl/hmac-secret;" --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --tls "ca-cert=/dgraph-tls/ca.crt;
-      server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true;
+      --acl "secret-file=/dgraph-acl/hmac-secret;" --security "whitelist=0.0.0.0/0;" --tls
+      "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt;
+      server-key=/dgraph-tls/node.key; internal-port=true;
       client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;
       client-auth-type=VERIFYIFGIVEN;"
   zero1:

--- a/tlstest/certrequest/docker-compose.yml
+++ b/tlstest/certrequest/docker-compose.yml
@@ -21,9 +21,8 @@ services:
         read_only: true
     command:
       /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --tls
-      "ca-cert=/dgraph-tls/ca.crt; client-auth-type=REQUEST; server-cert=/dgraph-tls/node.crt;
-      server-key=/dgraph-tls/node.key;"
+      --security "whitelist=0.0.0.0/0;" --tls "ca-cert=/dgraph-tls/ca.crt; client-auth-type=REQUEST;
+      server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key;"
   zero1:
     image: dgraph/dgraph:local
     working_dir: /data/zero1

--- a/tlstest/certrequireandverify/docker-compose.yml
+++ b/tlstest/certrequireandverify/docker-compose.yml
@@ -21,9 +21,9 @@ services:
         read_only: true
     command:
       /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --tls
-      "ca-cert=/dgraph-tls/ca.crt; client-auth-type=REQUIREANDVERIFY;
-      server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key;"
+      --security "whitelist=0.0.0.0/0;" --tls "ca-cert=/dgraph-tls/ca.crt;
+      client-auth-type=REQUIREANDVERIFY; server-cert=/dgraph-tls/node.crt;
+      server-key=/dgraph-tls/node.key;"
   zero1:
     image: dgraph/dgraph:local
     working_dir: /data/zero1

--- a/tlstest/certverifyifgiven/docker-compose.yml
+++ b/tlstest/certverifyifgiven/docker-compose.yml
@@ -21,8 +21,8 @@ services:
         read_only: true
     command:
       /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --tls
-      "ca-cert=/dgraph-tls/ca.crt; client-auth-type=VERIFYIFGIVEN; server-cert=/dgraph-tls/node.crt;
+      --security "whitelist=0.0.0.0/0;" --tls "ca-cert=/dgraph-tls/ca.crt;
+      client-auth-type=VERIFYIFGIVEN; server-cert=/dgraph-tls/node.crt;
       server-key=/dgraph-tls/node.key;"
   zero1:
     image: dgraph/dgraph:local

--- a/tlstest/mtls_internal/ha_6_node/docker-compose.yml
+++ b/tlstest/mtls_internal/ha_6_node/docker-compose.yml
@@ -19,9 +19,8 @@ services:
         read_only: true
     command:
       /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --tls
-      "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt;
-      server-key=/dgraph-tls/node.key; internal-port=true;
+      --security "whitelist=0.0.0.0/0;" --tls "ca-cert=/dgraph-tls/ca.crt;
+      server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true;
       client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   alpha2:
     image: dgraph/dgraph:local
@@ -42,9 +41,8 @@ services:
         read_only: true
     command:
       /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --tls
-      "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt;
-      server-key=/dgraph-tls/node.key; internal-port=true;
+      --security "whitelist=0.0.0.0/0;" --tls "ca-cert=/dgraph-tls/ca.crt;
+      server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true;
       client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
   alpha3:
     image: dgraph/dgraph:local
@@ -65,9 +63,8 @@ services:
         read_only: true
     command:
       /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --tls
-      "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt;
-      server-key=/dgraph-tls/node.key; internal-port=true;
+      --security "whitelist=0.0.0.0/0;" --tls "ca-cert=/dgraph-tls/ca.crt;
+      server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true;
       client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
   zero1:
     image: dgraph/dgraph:local

--- a/tlstest/mtls_internal/multi_group/docker-compose.yml
+++ b/tlstest/mtls_internal/multi_group/docker-compose.yml
@@ -19,9 +19,8 @@ services:
         read_only: true
     command:
       /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --tls
-      "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt;
-      server-key=/dgraph-tls/node.key; internal-port=true;
+      --security "whitelist=0.0.0.0/0;" --tls "ca-cert=/dgraph-tls/ca.crt;
+      server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true;
       client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   alpha2:
     image: dgraph/dgraph:local
@@ -42,9 +41,8 @@ services:
         read_only: true
     command:
       /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --tls
-      "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt;
-      server-key=/dgraph-tls/node.key; internal-port=true;
+      --security "whitelist=0.0.0.0/0;" --tls "ca-cert=/dgraph-tls/ca.crt;
+      server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true;
       client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
   alpha3:
     image: dgraph/dgraph:local
@@ -65,9 +63,8 @@ services:
         read_only: true
     command:
       /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --tls
-      "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt;
-      server-key=/dgraph-tls/node.key; internal-port=true;
+      --security "whitelist=0.0.0.0/0;" --tls "ca-cert=/dgraph-tls/ca.crt;
+      server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true;
       client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
   zero1:
     image: dgraph/dgraph:local

--- a/tlstest/mtls_internal/single_node/docker-compose.yml
+++ b/tlstest/mtls_internal/single_node/docker-compose.yml
@@ -19,9 +19,8 @@ services:
         read_only: true
     command:
       /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --tls
-      "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt;
-      server-key=/dgraph-tls/node.key; internal-port=true;
+      --security "whitelist=0.0.0.0/0;" --tls "ca-cert=/dgraph-tls/ca.crt;
+      server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true;
       client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   zero1:
     image: dgraph/dgraph:local

--- a/tlstest/zero_https/all_routes_tls/docker-compose.yml
+++ b/tlstest/zero_https/all_routes_tls/docker-compose.yml
@@ -17,7 +17,7 @@ services:
         read_only: true
     command:
       /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      --security "whitelist=0.0.0.0/0;"
   zero1:
     image: dgraph/dgraph:local
     working_dir: /data/zero1

--- a/tlstest/zero_https/no_tls/docker-compose.yml
+++ b/tlstest/zero_https/no_tls/docker-compose.yml
@@ -17,7 +17,7 @@ services:
         read_only: true
     command:
       /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      --security "whitelist=0.0.0.0/0;"
   zero1:
     image: dgraph/dgraph:local
     working_dir: /data/zero1

--- a/worker/docker-compose.yml
+++ b/worker/docker-compose.yml
@@ -18,8 +18,7 @@ services:
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --trace "jaeger=http://jaeger:14268;" --my=alpha1:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=1; group=1;
-      snapshot-after-entries=100; snapshot-after-duration=1m" --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=0.0.0.0/0;"
   alpha2:
     image: dgraph/dgraph:local
     working_dir: /data/alpha2
@@ -36,8 +35,7 @@ services:
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --trace "jaeger=http://jaeger:14268;" --my=alpha2:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=2; group=1;
-      snapshot-after-entries=100; snapshot-after-duration=1m" --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=0.0.0.0/0;"
   alpha3:
     image: dgraph/dgraph:local
     working_dir: /data/alpha3
@@ -54,8 +52,7 @@ services:
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --trace "jaeger=http://jaeger:14268;" --my=alpha3:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=3; group=1;
-      snapshot-after-entries=100; snapshot-after-duration=1m" --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=0.0.0.0/0;"
   alpha4:
     image: dgraph/dgraph:local
     working_dir: /data/alpha4
@@ -72,8 +69,7 @@ services:
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --trace "jaeger=http://jaeger:14268;" --my=alpha4:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=4; group=2;
-      snapshot-after-entries=100; snapshot-after-duration=1m" --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=0.0.0.0/0;"
   alpha5:
     image: dgraph/dgraph:local
     working_dir: /data/alpha5
@@ -90,8 +86,7 @@ services:
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --trace "jaeger=http://jaeger:14268;" --my=alpha5:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=5; group=2;
-      snapshot-after-entries=100; snapshot-after-duration=1m" --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=0.0.0.0/0;"
   alpha6:
     image: dgraph/dgraph:local
     working_dir: /data/alpha6
@@ -108,8 +103,7 @@ services:
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --trace "jaeger=http://jaeger:14268;" --my=alpha6:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=6; group=2;
-      snapshot-after-entries=100; snapshot-after-duration=1m" --security
-      "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=0.0.0.0/0;"
   jaeger:
     image: jaegertracing/all-in-one:1.60
     working_dir: /working/jaeger


### PR DESCRIPTION
**Description**

This PR changes the security/whitelist superflag definition in docker compose files and other places where docker cmds are issued. The change is to the "all ipv4 addresses" CIDR definition (0.0.0.0/0).

Background: after updating Docker on my Mac, clients presented a new 175.x ip address that was not covered by the old set of CIDR definitions.

**Checklist**

- [x] Code compiles correctly and linting passes locally