### PR TITLE
fix(cache): Estimate size of posting lists

### DIFF
--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -370,7 +370,7 @@ func (c *Cache) set(key []byte, i *CachePL) {
 		return
 	}
 	c.numCacheSave.Add(1)
-	c.data.Set(key, i, 1)
+	c.data.Set(key, i, 0)
 }
 
 func (c *Cache) del(key []byte) {
@@ -508,14 +508,18 @@ func initMemoryLayer(cacheSize int64, removeOnUpdate bool) *MemoryLayer {
 	ml.removeOnUpdate = removeOnUpdate
 	ml.statsHolder = NewStatsHolder()
 	if cacheSize > 0 {
-		cache, err := ristretto.NewCache[[]byte, *CachePL](&ristretto.Config[[]byte, *CachePL]{
+		cache, err := ristretto.NewCache(&ristretto.Config[[]byte, *CachePL]{
 			// Use 5% of cache memory for storing counters.
 			NumCounters: int64(float64(cacheSize) * 0.05 * 2),
 			MaxCost:     int64(float64(cacheSize) * 0.95),
 			BufferItems: 16,
 			Metrics:     true,
 			Cost: func(val *CachePL) int64 {
-				return 1
+				itemSize := int64(8)
+				if val.list != nil {
+					itemSize += int64(val.list.ApproximateSize())
+				}
+				return itemSize
 			},
 			ShouldUpdate: func(cur, prev *CachePL) bool {
 				return !(cur.list != nil && prev.list != nil && prev.list.maxTs > cur.list.maxTs)

--- a/posting/size.go
+++ b/posting/size.go
@@ -16,6 +16,97 @@ import (
 
 const sizeOfBucket = 144
 
+func (l *List) ApproximateSize() uint64 {
+	if l == nil {
+		return 0
+	}
+
+	l.RLock()
+	defer l.RUnlock()
+
+	var size uint64 = 4*8 + // safe mutex consists of 4 words.
+		1*8 + // plist pointer consists of 1 word.
+		1*8 + // mutation map pointer  consists of 1 word.
+		2*8 + // minTs and maxTs take 1 word each.
+		3*8 + // array take 3 words. so key array is 3 words.
+		3*8 + // array take 3 words. so cache array is 3 words.
+		1*8 // So far 11 words, in order to round the slab we're adding one more word.
+	// so far basic struct layout has been calculated.
+
+	// add byte array memory
+	size += uint64(cap(l.key)) + uint64(cap(l.cache))
+
+	size += approxPostingListSize(l.plist)
+
+	if l.mutationMap != nil {
+		size += l.mutationMap.ApproximateSize()
+	}
+
+	return size
+}
+
+func approxPostingListSize(list *pb.PostingList) uint64 {
+	if list == nil {
+		return 0
+	}
+
+	var size uint64 = 1*8 + // Pack consists of 1 word.
+		3*8 + // Postings array consists of 3 words.
+		1*8 + // CommitTs consists of 1 word.
+		3*8 // Splits array consists of 3 words.
+
+	// add pack size.
+	size += calculatePackSize(list.Pack)
+
+	// Each entry take one word.
+	// Adding each entry reference allocation.
+	size += uint64(cap(list.Postings)) * 8
+	for _, p := range list.Postings {
+		// add the size of each posting.
+		size += calculatePostingSize(p) * uint64(cap(list.Postings))
+		break
+	}
+
+	// Each entry take one word.
+	// Adding each entry size.
+	size += uint64(cap(list.Splits)) * 8
+
+	return size
+}
+
+func (m *MutableLayer) ApproximateSize() uint64 {
+	if m == nil {
+		return 0
+	}
+
+	var size uint64 = 2*8 + // committedEntries and currentEntries take 2 words each.
+		1*8 + // readTs takes 1 word.
+		1*8 + // deleteAllMarker takes 1 word.
+		1*8 + // committedUids takes 1 word.
+		1*8 + // committedUidsTime takes 1 word.
+		1*8 + // length takes 1 word.
+		1*8 + // lastEntry takes 1 word.
+		1*8 + // committedUidsTime takes 1 word.
+		1*8 + // isUidsCalculated takes 1 word.
+		1*8 // calculatedUids takes 1 word.
+	// so far basic struct layout has been calculated.
+
+	// Add each entry size of committedEntries.
+	size += uint64(len(m.committedEntries)) * 8
+	for _, v := range m.committedUids {
+		size += calculatePostingSize(v) * uint64(len(m.committedEntries))
+		break
+	}
+
+	size += approxPostingListSize(m.currentEntries)
+	size += approxPostingListSize(m.lastEntry)
+
+	size += uint64(len(m.currentUids)) * 8
+	size += uint64(cap(m.calculatedUids)) * 8
+
+	return size
+}
+
 // DeepSize computes the memory taken by a Posting List
 func (l *List) DeepSize() uint64 {
 	if l == nil {

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -41,7 +41,7 @@ const (
 	ZeroLimitsDefaults = `uid-lease=0; refill-interval=30s; disable-admin-http=false;`
 	GraphQLDefaults    = `introspection=true; debug=false; extensions=true; poll-interval=1s; ` +
 		`lambda-url=;`
-	CacheDefaults        = `size-mb=1024; percentage=40,40,20; remove-on-update=false`
+	CacheDefaults        = `size-mb=4096; percentage=40,40,20; remove-on-update=false`
 	FeatureFlagsDefaults = `normalize-compatibility-mode=; enable-detailed-metrics=false`
 )
 


### PR DESCRIPTION
**Description**

The maximum cost of the Ristretto cache is set to a number of megabytes, but when inserting a posting list item into the cache, the cost is set to 1. Because of this the cache only grows and no items get evicted. This results in high memory consumption, especially with the new UID cache (see #9513). 

This PR introduces a cost function which estimates the memory size of each item. For more details see https://github.com/predictable-labs/dgraph/issues/6. Credits to @darkcoderrises for the implementation.

The default cache size is changed from 1024 to 4096, to reflect the more accurate cost estimation. See below for how the size of the cache relates to the occupied memory by the Dgrpah process, when this PR is applied.



size-mb=1024

Dgraph process occupies up to 3.7 GiB of memory

heap:

```
  344.49MB 30.34% 30.34%   407.26MB 35.87%  github.com/hypermodeinc/dgraph/v25/posting.(*List).calculateUids
  130.37MB 11.48% 41.83%   130.37MB 11.48%  github.com/dgraph-io/ristretto/v2.newCmRow
   83.20MB  7.33% 49.15%    83.20MB  7.33%  github.com/dgraph-io/badger/v4/skl.newArena
   69.50MB  6.12% 55.28%    69.50MB  6.12%  github.com/hypermodeinc/dgraph/v25/posting.(*List).Uids.func1
   65.16MB  5.74% 61.02%    65.16MB  5.74%  github.com/dgraph-io/ristretto/v2/z.(*Bloom).Size
   53.27MB  4.69% 65.71%    53.27MB  4.69%  github.com/hypermodeinc/dgraph/v25/posting.(*List).calculateUids.func1
```
   
   
size-mb=2048

Dgraph process occupies up to 5.4 GiB of memory

heap:
```
  637.07MB 33.68% 33.68%   699.33MB 36.97%  github.com/hypermodeinc/dgraph/v25/posting.(*List).calculateUids
  260.63MB 13.78% 47.46%   260.63MB 13.78%  github.com/dgraph-io/ristretto/v2.newCmRow
  130.04MB  6.88% 54.34%   130.04MB  6.88%  github.com/dgraph-io/ristretto/v2/z.(*Bloom).Size
   99.01MB  5.23% 59.57%    99.01MB  5.23%  github.com/hypermodeinc/dgraph/v25/posting.(*List).Uids.func1
   89.89MB  4.75% 64.32%    89.89MB  4.75%  github.com/dgraph-io/ristretto/v2.(*lockedMap[go.shape.*uint8]).Set
   83.20MB  4.40% 68.72%    83.20MB  4.40%  github.com/dgraph-io/badger/v4/skl.newArena
```

size-mb=4096

Dgraph process occupies up to 8.4 GiB of memory

heap:

```
 1343.44MB 41.61% 41.61%  1404.71MB 43.51%  github.com/hypermodeinc/dgraph/v25/posting.(*List).calculateUids
  520.15MB 16.11% 57.72%   520.15MB 16.11%  github.com/dgraph-io/ristretto/v2.newCmRow
     260MB  8.05% 65.77%      260MB  8.05%  github.com/dgraph-io/ristretto/v2/z.(*Bloom).Size
  136.70MB  4.23% 70.01%   136.70MB  4.23%  github.com/dgraph-io/ristretto/v2.(*lockedMap[go.shape.*uint8]).Set
  106.51MB  3.30% 73.31%   106.51MB  3.30%  reflect.New
   83.20MB  2.58% 75.88%    83.20MB  2.58%  github.com/dgraph-io/badger/v4/skl.newArena
```

size-mb=8192

Dgraph process occupies up to 13.3 GiB of memory

heap:

```
 2539.78MB 45.10% 45.10%  2601.10MB 46.19%  github.com/hypermodeinc/dgraph/v25/posting.(*List).calculateUids
 1040.01MB 18.47% 63.56%  1040.01MB 18.47%  github.com/dgraph-io/ristretto/v2.newCmRow
     520MB  9.23% 72.80%      520MB  9.23%  github.com/dgraph-io/ristretto/v2/z.(*Bloom).Size
  223.52MB  3.97% 76.77%   223.52MB  3.97%  reflect.New
  157.97MB  2.81% 79.57%   157.97MB  2.81%  github.com/dgraph-io/ristretto/v2.(*lockedMap[go.shape.*uint8]).Set
  136.01MB  2.42% 81.99%   259.03MB  4.60%  github.com/hypermodeinc/dgraph/v25/posting.copyList
```




Closes #9513
