### PR TITLE
fix(cache): make updating the max cost of posting cache work again

### DIFF
--- a/posting/lists.go
+++ b/posting/lists.go
@@ -46,9 +46,6 @@ func SetEnabledDetailedMetrics(enableMetrics bool) {
 	EnableDetailedMetrics = enableMetrics
 }
 
-func UpdateMaxCost(maxCost int64) {
-}
-
 // Cleanup waits until the closer has finished processing.
 func Cleanup() {
 	closer.SignalAndWait()

--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -405,6 +405,13 @@ func (ml *MemoryLayer) del(key []byte) {
 	ml.cache.del(key)
 }
 
+func (ml *MemoryLayer) UpdateMaxCost(maxCost int64) {
+	if ml.cache == nil || ml.cache.data == nil {
+		return
+	}
+	ml.cache.data.UpdateMaxCost(maxCost)
+}
+
 type IterateDiskArgs struct {
 	Prefix         []byte
 	Prefetch       bool

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -150,7 +150,9 @@ func UpdateCacheMb(memoryMB int64) error {
 	blockCacheSize := (cachePercent[1] * (memoryMB << 20)) / 100
 	indexCacheSize := (cachePercent[2] * (memoryMB << 20)) / 100
 
-	posting.UpdateMaxCost(plCacheSize)
+	if posting.MemLayerInstance != nil {
+		posting.MemLayerInstance.UpdateMaxCost(plCacheSize)
+	}
 	if _, err := pstore.CacheMaxCost(badger.BlockCache, blockCacheSize); err != nil {
 		return errors.Wrapf(err, "cannot update block cache size")
 	}


### PR DESCRIPTION
Updating the max cost of the posting list cache is not wired up. It just calls an empty function. This PR adds a method to `MemoryLayer`, that allows updating the max cost of its cache. The old function is deleted and the function call is replaced with a call to the new method.