### PR TITLE
chore(core): use Tick() instead of NewTicker()

### DIFF
--- a/conn/node_test.go
+++ b/conn/node_test.go
@@ -22,12 +22,11 @@ import (
 )
 
 func (n *Node) run(wg *sync.WaitGroup) {
-	ticker := time.NewTicker(20 * time.Millisecond)
-	defer ticker.Stop()
+	ticker := time.Tick(20 * time.Millisecond)
 
 	for {
 		select {
-		case <-ticker.C:
+		case <-ticker:
 			n.Raft().Tick()
 		case rd := <-n.Raft().Ready():
 			n.SaveToStorage(&rd.HardState, rd.Entries, &rd.Snapshot)

--- a/contrib/jepsen/main.go
+++ b/contrib/jepsen/main.go
@@ -237,18 +237,15 @@ func jepsenServe() error {
 		// lein run serve runs indefinitely, so there's no need to wait for the
 		// command to finish.
 		_ = cmd.Start()
-		ticker := time.NewTicker(time.Second)
-		defer ticker.Stop()
-
+		ticker := time.Tick(time.Second)
 		timeout := time.NewTimer(5 * time.Minute)
-		defer timeout.Stop()
 		for {
 			select {
 			case <-timeout.C:
 				wg.Done()
 				errCh <- errors.New("lein run serve couldn't run after 5 minutes")
 				return
-			case <-ticker.C:
+			case <-ticker:
 				if err := checkServing(); err == nil {
 					wg.Done()
 					errCh <- nil

--- a/dgraph/cmd/bulk/progress.go
+++ b/dgraph/cmd/bulk/progress.go
@@ -56,13 +56,12 @@ func (p *progress) setPhase(ph phase) {
 }
 
 func (p *progress) report() {
-	t := time.NewTicker(time.Second)
-	defer t.Stop()
+	t := time.Tick(time.Second)
 
 	z.StatsPrint() // Just print once.
 	for {
 		select {
-		case <-t.C:
+		case <-t:
 			p.reportOnce()
 		case <-p.shutdown:
 			p.shutdown <- struct{}{}

--- a/dgraph/cmd/bulk/reduce.go
+++ b/dgraph/cmd/bulk/reduce.go
@@ -478,8 +478,7 @@ func (r *reducer) reduce(partitionKeys [][]byte, mapItrs []*mapIterator, ci *cou
 		writerCh <- req
 	}
 
-	ticker := time.NewTicker(time.Minute)
-	defer ticker.Stop()
+	ticker := time.Tick(time.Minute)
 
 	buffers := make(chan *z.Buffer, 3)
 
@@ -502,7 +501,7 @@ func (r *reducer) reduce(partitionKeys [][]byte, mapItrs []*mapIterator, ci *cou
 
 			hd.Update(int64(cbuf.LenNoPadding()))
 			select {
-			case <-ticker.C:
+			case <-ticker:
 				fmt.Printf("Histogram of buffer sizes: %s\n", hd.String())
 			default:
 			}

--- a/dgraph/cmd/increment/increment_test.go
+++ b/dgraph/cmd/increment/increment_test.go
@@ -203,7 +203,6 @@ func TestBestEffortOnly(t *testing.T) {
 	}()
 
 	timer := time.NewTimer(15 * time.Second)
-	defer timer.Stop()
 
 	select {
 	case <-timer.C:

--- a/dgraph/cmd/zero/oracle.go
+++ b/dgraph/cmd/zero/oracle.go
@@ -184,8 +184,7 @@ func (o *Oracle) removeSubscriber(id int) {
 // and sends the delta object to each subscriber's channel
 func (o *Oracle) sendDeltasToSubscribers() {
 	delta := &pb.OracleDelta{}
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
+	ticker := time.Tick(time.Second)
 
 	// waitFor calculates the maximum value of delta.MaxAssigned and all the CommitTs of delta.Txns
 	waitFor := func() uint64 {
@@ -201,7 +200,7 @@ func (o *Oracle) sendDeltasToSubscribers() {
 		var update *pb.OracleDelta
 		select {
 		case update = <-o.updates:
-		case <-ticker.C:
+		case <-ticker:
 			wait := waitFor()
 			if wait == 0 || o.doneUntil.DoneUntil() < wait {
 				goto get_update

--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -690,12 +690,11 @@ func (n *node) initAndStartNode() error {
 
 func (n *node) updateZeroMembershipPeriodically(closer *z.Closer) {
 	defer closer.Done()
-	ticker := time.NewTicker(10 * time.Second)
-	defer ticker.Stop()
+	ticker := time.Tick(10 * time.Second)
 
 	for {
 		select {
-		case <-ticker.C:
+		case <-ticker:
 			n.server.updateZeroLeader()
 		case <-closer.HasBeenClosed():
 			return
@@ -705,8 +704,7 @@ func (n *node) updateZeroMembershipPeriodically(closer *z.Closer) {
 
 func (n *node) checkQuorum(closer *z.Closer) {
 	defer closer.Done()
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
+	ticker := time.Tick(time.Second)
 
 	quorum := func() {
 		// Make this timeout 1.5x the timeout on RunReadIndexLoop.
@@ -733,7 +731,7 @@ func (n *node) checkQuorum(closer *z.Closer) {
 
 	for {
 		select {
-		case <-ticker.C:
+		case <-ticker:
 			// Only the leader needs to check for the quorum. The quorum is
 			// used by a leader to identify if it is behind a network partition.
 			if n.amLeader() {
@@ -747,12 +745,11 @@ func (n *node) checkQuorum(closer *z.Closer) {
 
 func (n *node) snapshotPeriodically(closer *z.Closer) {
 	defer closer.Done()
-	ticker := time.NewTicker(time.Minute)
-	defer ticker.Stop()
+	ticker := time.Tick(time.Minute)
 
 	for {
 		select {
-		case <-ticker.C:
+		case <-ticker:
 			if err := n.calculateAndProposeSnapshot(); err != nil {
 				glog.Errorf("While calculateAndProposeSnapshot: %v", err)
 			}
@@ -873,8 +870,7 @@ func (n *node) Run() {
 	lastLead := uint64(math.MaxUint64)
 
 	var leader bool
-	ticker := time.NewTicker(tickDur)
-	defer ticker.Stop()
+	ticker := time.Tick(tickDur)
 
 	// snapshot can cause select loop to block while deleting entries, so run
 	// it in goroutine
@@ -911,7 +907,7 @@ func (n *node) Run() {
 		case <-n.closer.HasBeenClosed():
 			n.Raft().Stop()
 			return
-		case <-ticker.C:
+		case <-ticker:
 			n.Raft().Tick()
 		case rd := <-n.Raft().Ready():
 			timer.Start()

--- a/dgraph/cmd/zero/tablet.go
+++ b/dgraph/cmd/zero/tablet.go
@@ -51,8 +51,8 @@ This would trigger G1 to get latest state. Wait for it.
 
 // TODO: Have a event log for everything.
 func (s *Server) rebalanceTablets() {
-	ticker := time.NewTicker(opts.rebalanceInterval)
-	for range ticker.C {
+	ticker := time.Tick(opts.rebalanceInterval)
+	for range ticker {
 		predicate, srcGroup, dstGroup := s.chooseTablet()
 		if len(predicate) == 0 {
 			continue

--- a/dgraph/cmd/zero/zero.go
+++ b/dgraph/cmd/zero/zero.go
@@ -106,11 +106,10 @@ func (s *Server) periodicallyPostTelemetry() {
 
 	glog.Infof("Starting telemetry data collection for zero...")
 
-	ticker := time.NewTicker(6 * time.Hour)
-	defer ticker.Stop()
+	ticker := time.Tick(6 * time.Hour)
 
 	var lastPostedAt time.Time
-	for range ticker.C {
+	for range ticker {
 		if !s.Node.AmLeader() {
 			continue
 		}
@@ -832,11 +831,11 @@ func (s *Server) StreamMembership(_ *api.Payload, stream pb.Zero_StreamMembershi
 		return err
 	}
 
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
+	ticker := time.Tick(time.Second)
+
 	for {
 		select {
-		case <-ticker.C:
+		case <-ticker:
 			// Send an update every second.
 			ms, err := s.latestMembershipState(ctx)
 			if err != nil {

--- a/dgraph/main.go
+++ b/dgraph/main.go
@@ -29,7 +29,7 @@ func main() {
 		return b - a
 	}
 
-	ticker := time.NewTicker(10 * time.Second)
+	ticker := time.Tick(10 * time.Second)
 
 	// Make sure the garbage collector is run periodically.
 	go func() {
@@ -42,7 +42,7 @@ func main() {
 		var js z.MemStats
 		var lastAlloc uint64
 
-		for range ticker.C {
+		for range ticker {
 			// Read Jemalloc stats first. Print if there's a big difference.
 			z.ReadMemStats(&js)
 			if diff := absDiff(uint64(z.NumAllocBytes()), lastAlloc); diff > 1<<30 {
@@ -83,7 +83,6 @@ func main() {
 
 	// Run the program.
 	cmd.Execute()
-	ticker.Stop()
 
 	glog.V(2).Infof("Num Allocated Bytes at program end: %d", z.NumAllocBytes())
 	if z.NumAllocBytes() > 0 {

--- a/dgraphapi/json.go
+++ b/dgraphapi/json.go
@@ -25,8 +25,8 @@ const (
 )
 
 func PollTillPassOrTimeout(gcli *GrpcClient, query, want string, timeout time.Duration) error {
-	ticker := time.NewTimer(requestTimeout)
-	defer ticker.Stop()
+	timer := time.NewTimer(timeout)
+
 	for {
 		resp, err := gcli.Query(query)
 		if err != nil {
@@ -38,7 +38,7 @@ func PollTillPassOrTimeout(gcli *GrpcClient, query, want string, timeout time.Du
 			return nil
 		}
 		select {
-		case <-ticker.C:
+		case <-timer.C:
 			return err
 		default:
 			time.Sleep(waitDurBeforeRetry)

--- a/query/mutation.go
+++ b/query/mutation.go
@@ -121,12 +121,11 @@ func verifyUid(ctx context.Context, uid uint64) error {
 		return nil
 	}
 	deadline := time.Now().Add(3 * time.Second)
-	ticker := time.NewTicker(100 * time.Millisecond)
-	defer ticker.Stop()
+	ticker := time.Tick(100 * time.Millisecond)
 
 	for {
 		select {
-		case <-ticker.C:
+		case <-ticker:
 			lease := worker.MaxLeaseId()
 			if uid <= lease {
 				return nil

--- a/testutil/utils.go
+++ b/testutil/utils.go
@@ -129,10 +129,9 @@ func JsonGet(j interface{}, components ...string) interface{} {
 }
 
 func PollTillPassOrTimeout(t *testing.T, dc *dgo.Dgraph, query, want string, timeout time.Duration) {
-	ticker := time.NewTicker(time.Millisecond)
-	defer ticker.Stop()
+	ticker := time.Tick(time.Millisecond)
 	to := time.NewTimer(timeout)
-	defer to.Stop()
+
 	for {
 		select {
 		case <-to.C:
@@ -140,7 +139,7 @@ func PollTillPassOrTimeout(t *testing.T, dc *dgo.Dgraph, query, want string, tim
 			gotMap := UnmarshalJSON(t, string(QueryData(t, dc, query)))
 			DiffJSONMaps(t, wantMap, gotMap, "", false)
 			return // timeout
-		case <-ticker.C:
+		case <-ticker:
 			wantMap := UnmarshalJSON(t, want)
 			gotMap := UnmarshalJSON(t, string(QueryData(t, dc, query)))
 			if DiffJSONMaps(t, wantMap, gotMap, "", true) {

--- a/worker/cdc.go
+++ b/worker/cdc.go
@@ -324,23 +324,21 @@ func (cdc *CDC) processCDCEvents() {
 		return nil
 	}
 
-	jobTick := time.NewTicker(time.Second)
-	proposalTick := time.NewTicker(3 * time.Minute)
+	jobTick := time.Tick(time.Second)
+	proposalTick := time.Tick(3 * time.Minute)
 	defer cdc.closer.Done()
-	defer jobTick.Stop()
-	defer proposalTick.Stop()
 	var lastSent uint64
 	for {
 		select {
 		case <-cdc.closer.HasBeenClosed():
 			return
-		case <-jobTick.C:
+		case <-jobTick:
 			if groups().Node.AmLeader() {
 				if err := sendEvents(); err != nil {
 					glog.Errorf("unable to send events %+v", err)
 				}
 			}
-		case <-proposalTick.C:
+		case <-proposalTick:
 			// The leader would propose the max sentTs over to the group.
 			// So, in case of a crash or a leadership change, the new leader
 			// would know where to send the cdc events from the Raft logs.

--- a/worker/proposal.go
+++ b/worker/proposal.go
@@ -50,10 +50,9 @@ type rateLimiter struct {
 // account. We however, limit solely based on feedback, allowing a certain
 // number of ops to remain pending, and not anymore.
 func (rl *rateLimiter) bleed() {
-	tick := time.NewTicker(time.Second)
-	defer tick.Stop()
+	tick := time.Tick(time.Second)
 
-	for range tick.C {
+	for range tick {
 		rl.c.L.Lock()
 		iou := rl.iou
 		rl.c.L.Unlock()
@@ -238,7 +237,6 @@ func (n *node) proposeAndWait(ctx context.Context, proposal *pb.Proposal) (perr 
 		}
 
 		timer := time.NewTimer(timeout)
-		defer timer.Stop()
 
 		for {
 			select {

--- a/worker/proposal_test.go
+++ b/worker/proposal_test.go
@@ -62,12 +62,11 @@ func TestLimiterDeadlock(t *testing.T) {
 	l := &rateLimiter{c: sync.NewCond(&sync.Mutex{}), max: 256}
 	go l.bleed()
 
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
+	ticker := time.Tick(time.Second)
 
 	go func() {
 		now := time.Now()
-		for range ticker.C {
+		for range ticker {
 			l.c.L.Lock()
 			fmt.Println("Seconds elapsed :", int64(time.Since(now).Seconds()),
 				"Total proposals: ", atomic.LoadInt64(&currentCount),
@@ -100,7 +99,6 @@ func TestLimiterDeadlock(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
-	ticker.Stop()
 
 	// After trying all the proposals, (completed + aborted) should be equal to  tried proposal.
 	require.True(t, toTry == completed+aborted,

--- a/worker/queue.go
+++ b/worker/queue.go
@@ -210,8 +210,8 @@ func (t *tasks) get(id uint64) (TaskMeta, error) {
 
 // worker loops forever, running queued tasks one at a time. Any returned errors are logged.
 func (t *tasks) worker() {
-	shouldCleanup := time.NewTicker(time.Hour)
-	defer shouldCleanup.Stop()
+	shouldCleanup := time.Tick(time.Hour)
+
 	for {
 		// If the server is shutting down, return immediately. Else, fetch a task from the queue.
 		var task taskRequest
@@ -221,7 +221,7 @@ func (t *tasks) worker() {
 				glog.Warningf("error closing log file: %v", err)
 			}
 			return
-		case <-shouldCleanup.C:
+		case <-shouldCleanup:
 			t.cleanup()
 		case task = <-t.queue:
 			if err := t.run(task); err != nil {

--- a/worker/restore_map.go
+++ b/worker/restore_map.go
@@ -649,8 +649,7 @@ func (m *mapper) processReqCh(ctx context.Context) error {
 func (m *mapper) Progress() {
 	defer m.closer.Done()
 
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
+	ticker := time.Tick(time.Second)
 
 	start := time.Now()
 	update := func() {
@@ -668,7 +667,7 @@ func (m *mapper) Progress() {
 			update()
 			glog.Infof("Restore MAP Done in %s.\n", x.FixedDuration(time.Since(start)))
 			return
-		case <-ticker.C:
+		case <-ticker:
 			update()
 		}
 	}

--- a/worker/restore_reduce.go
+++ b/worker/restore_reduce.go
@@ -143,8 +143,7 @@ func RunReducer(w Writer, mapDir string) error {
 func (r *reducer) Progress(closer *z.Closer) {
 	defer closer.Done()
 
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
+	ticker := time.Tick(time.Second)
 
 	start := time.Now()
 	update := func() {
@@ -163,7 +162,7 @@ func (r *reducer) Progress(closer *z.Closer) {
 			update()
 			glog.Infof("Restore REDUCE Done in %s.\n", x.FixedDuration(time.Since(start)))
 			return
-		case <-ticker.C:
+		case <-ticker:
 			update()
 		}
 	}

--- a/worker/task.go
+++ b/worker/task.go
@@ -84,7 +84,6 @@ func processWithBackupRequest(
 	}()
 
 	timer := time.NewTimer(backupRequestGracePeriod)
-	defer timer.Stop()
 
 	select {
 	case <-ctx.Done():
@@ -112,7 +111,6 @@ func processWithBackupRequest(
 	case result := <-chResults:
 		if result.err != nil {
 			cancel() // Might as well cleanup resources ASAP
-			timer.Stop()
 			return invokeNetworkRequest(ctx, addrs[1], f)
 		}
 		return result.reply, nil

--- a/x/disk_metrics_linux.go
+++ b/x/disk_metrics_linux.go
@@ -26,8 +26,7 @@ func MonitorDiskMetrics(dirTag string, dir string, lc *z.Closer) {
 	defer lc.Done()
 	ctx, err := tag.New(context.Background(), tag.Upsert(KeyDirType, dirTag))
 
-	fastTicker := time.NewTicker(10 * time.Second)
-	defer fastTicker.Stop()
+	fastTicker := time.Tick(10 * time.Second)
 
 	if err != nil {
 		glog.Errorln("Invalid Tag", err)
@@ -38,7 +37,7 @@ func MonitorDiskMetrics(dirTag string, dir string, lc *z.Closer) {
 		select {
 		case <-lc.HasBeenClosed():
 			return
-		case <-fastTicker.C:
+		case <-fastTicker:
 			s := syscall.Statfs_t{}
 			err = syscall.Statfs(dir, &s)
 			if err != nil {

--- a/x/x.go
+++ b/x/x.go
@@ -1183,9 +1183,7 @@ func IsSuperAdmin(groups []string) bool {
 func RunVlogGC(store *badger.DB, closer *z.Closer) {
 	defer closer.Done()
 
-	// Runs every 1m
-	ticker := time.NewTicker(1 * time.Minute)
-	defer ticker.Stop()
+	ticker := time.Tick(1 * time.Minute)
 
 	abs := func(a, b int64) int64 {
 		if a > b {
@@ -1212,7 +1210,7 @@ func RunVlogGC(store *badger.DB, closer *z.Closer) {
 		select {
 		case <-closer.HasBeenClosed():
 			return
-		case <-ticker.C:
+		case <-ticker:
 			runGC()
 		}
 	}
@@ -1226,11 +1224,11 @@ func StoreSync(db DB, closer *z.Closer) {
 	defer closer.Done()
 	// We technically don't need to call this due to mmap being able to survive process crashes.
 	// But, once a minute is infrequent enough that we won't lose any performance due to this.
-	ticker := time.NewTicker(time.Minute)
-	defer ticker.Stop()
+	ticker := time.Tick(time.Minute)
+
 	for {
 		select {
-		case <-ticker.C:
+		case <-ticker:
 			if err := db.Sync(); err != nil {
 				glog.Errorf("Error while calling db sync: %+v", err)
 			}
@@ -1514,13 +1512,13 @@ func (r *RateLimiter) RefillPeriodically() {
 		})
 	}
 
-	ticker := time.NewTicker(r.refillAfter)
-	defer ticker.Stop()
+	ticker := time.Tick(r.refillAfter)
+
 	for {
 		select {
 		case <-r.closer.HasBeenClosed():
 			return
-		case <-ticker.C:
+		case <-ticker:
 			refill()
 		}
 	}

--- a/xidmap/xidmap_test.go
+++ b/xidmap/xidmap_test.go
@@ -100,10 +100,10 @@ func TestXidmapMemory(t *testing.T) {
 		fmt.Printf(" Loop = %.2fM", float64(atomic.LoadUint32(&loop))/1e6)
 		fmt.Printf(" NumGC = %v\n", m.NumGC)
 	}
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
+	ticker := time.Tick(time.Second)
+
 	go func() {
-		for range ticker.C {
+		for range ticker {
 			printMemory()
 		}
 	}()


### PR DESCRIPTION
**Description**

- Replaces all uses of `time.NewTicker()` with `time.Tick()`. Since Go 1.23 the garbage collector can automatically clean up unreferenced tickers. Therefore, we can just use `Tick()` instead of `NewTicker()` and remove all `defer ticker.Stop()`. 
- Removes all calls to stop a timer. Similar to tickers, since Go 1.23 timers can also be garbage collected automatically without calling `timer.Stop()`.
- Remove two ticker member variables that were only used in a single function. 
- Changes the function `PollTillPassOrTimeout()` to use the `timeout` argument
