### PR TITLE
chore(test): replace deprecated docker struct types in testing harness

### DIFF
--- a/t/t.go
+++ b/t/t.go
@@ -26,7 +26,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
@@ -790,7 +789,7 @@ func removeAllTestContainers() {
 	var wg sync.WaitGroup
 	for _, c := range containers {
 		wg.Add(1)
-		go func(c types.Container) {
+		go func(c container.Summary) {
 			defer wg.Done()
 			o := container.StopOptions{Timeout: &dur}
 			err := cli.ContainerStop(ctxb, c.ID, o)


### PR DESCRIPTION
**Description**

`types.Container` and `types.ContainerJSON` from the docker page are deprecated. The documentation says they are going to be removed in the next release. This MR replaces the deprecated types throughout the code base with their modern equivalents.

Also changed `container` to `c` in `GetContainer()`, so the variable doesn't collide with the package name.