### PR TITLE
fix(cmd): store correct CA verification status

### DIFF
--- a/dgraph/cmd/cert/info.go
+++ b/dgraph/cmd/cert/info.go
@@ -85,10 +85,10 @@ func getFileInfo(file string) *certInfo {
 				info.err = errors.Wrapf(err, "could not read parent cert")
 				return &info
 			}
-			if err := cert.CheckSignatureFrom(parent); err != nil {
-				info.verifiedCA = "FAILED"
+			info.verifiedCA = "FAILED"
+			if err := cert.CheckSignatureFrom(parent); err == nil {
+				info.verifiedCA = "PASSED"
 			}
-			info.verifiedCA = "PASSED"
 		}
 
 	case strings.HasSuffix(file, ".key"):


### PR DESCRIPTION
**Description**

If `CheckSignatureFrom()` returns an error, the `verifiedCA` property  of `certInfo` should be set to `"FAILED"`. However, currently `verifiedCA` is always set to `"PASSED"`, ignoring the result of `CheckSignatureFrom()`. This PR sets the correct status.