### PR TITLE
chore(core): remove slash grpc handling

### DIFF
--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -33,7 +33,6 @@ type versionComparisonResult uint8
 const (
 	dryRun    = "dry-run"
 	alpha     = "alpha"
-	slashGrpc = "slash_grpc_endpoint"
 	authToken = "auth_token"
 	alphaHttp = "alpha-http"
 	user      = "user"
@@ -146,13 +145,8 @@ func init() {
 	flag.Bool(dryRun, false, "dry-run the upgrade")
 	flag.StringP(alpha, "a", "127.0.0.1:9080",
 		"Comma separated list of Dgraph Alpha gRPC server address")
-	flag.String(slashGrpc, "", "Path to Slash GraphQL GRPC endpoint. "+
-		"If --slash_grpc_endpoint is set, all other TLS options and connection options will be "+
-		"ignored")
 	flag.String(authToken, "",
-		"The auth token passed to the server for Alter operation of the schema file. "+
-			"If used with --slash_grpc_endpoint, then this should be set to the API token issued"+
-			"by Slash GraphQL")
+		"The auth token passed to the server for Alter operation of the schema file")
 	flag.String(alphaHttp, "http://127.0.0.1:8080", "Draph Alpha HTTP(S) endpoint.")
 	flag.StringP(user, "u", "", "Username of ACL user")
 	flag.StringP(password, "p", "", "Password of ACL user")

--- a/x/tls_helper.go
+++ b/x/tls_helper.go
@@ -147,31 +147,12 @@ func LoadServerTLSConfig(v *viper.Viper) (*tls.Config, error) {
 	return GenerateServerTLSConfig(&conf)
 }
 
-// SlashTLSConfig returns the TLS config appropriate for SlashGraphQL
-// This assumes that endpoint is not empty, and in the format "domain.grpc.cloud.dg.io:443"
-func SlashTLSConfig(endpoint string) (*tls.Config, error) {
-	pool, err := generateCertPool("", true)
-	if err != nil {
-		return nil, err
-	}
-	hostWithoutPort := strings.Split(endpoint, ":")[0]
-	return &tls.Config{
-		RootCAs:    pool,
-		ServerName: hostWithoutPort,
-		MinVersion: tls.VersionTLS12,
-	}, nil
-}
-
 // LoadClientTLSConfig loads the TLS config into the client with the given parameters.
 func LoadClientTLSConfig(v *viper.Viper) (*tls.Config, error) {
-	if v.GetString("slash_grpc_endpoint") != "" {
-		return SlashTLSConfig(v.GetString("slash_grpc_endpoint"))
-	}
-
 	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSDefaults)
 
 	// When the --tls ca-cert="..."; option is specified, the connection will be set up using TLS
-	// instead of plaintext. However the client cert files are optional, depending on whether the
+	// instead of plaintext. However, the client cert files are optional, depending on whether the
 	// server requires a client certificate.
 	caCert := tlsFlag.GetPath("ca-cert")
 	if caCert != "" {


### PR DESCRIPTION
**Description**

Dgraph Cloud is gone, so remove Slash GRPC endpoint handling from Dgraph.
