### PR TITLE
fix(vector): Fix similarity-based HNSW search for cosine and dot product metrics

### DIFF
--- a/tok/hnsw/heap.go
+++ b/tok/hnsw/heap.go
@@ -13,7 +13,7 @@ import (
 
 const notAUid uint64 = 0
 
-type minPersistentHeapElement[T c.Float] struct {
+type persistentHeapElement[T c.Float] struct {
 	value T
 	index uint64
 	// An element that is "filteredOut" is one that should be removed
@@ -23,15 +23,15 @@ type minPersistentHeapElement[T c.Float] struct {
 }
 
 func initPersistentHeapElement[T c.Float](
-	val T, i uint64, filteredOut bool) *minPersistentHeapElement[T] {
-	return &minPersistentHeapElement[T]{
+	val T, i uint64, filteredOut bool) *persistentHeapElement[T] {
+	return &persistentHeapElement[T]{
 		value:       val,
 		index:       i,
 		filteredOut: filteredOut,
 	}
 }
 
-type minPersistentTupleHeap[T c.Float] []minPersistentHeapElement[T]
+type minPersistentTupleHeap[T c.Float] []persistentHeapElement[T]
 
 func (h minPersistentTupleHeap[T]) Len() int {
 	return len(h)
@@ -46,7 +46,7 @@ func (h minPersistentTupleHeap[T]) Swap(i, j int) {
 }
 
 func (h *minPersistentTupleHeap[T]) Push(x interface{}) {
-	*h = append(*h, x.(minPersistentHeapElement[T]))
+	*h = append(*h, x.(persistentHeapElement[T]))
 }
 
 func (h *minPersistentTupleHeap[T]) PopLast() {
@@ -63,7 +63,7 @@ func (h *minPersistentTupleHeap[T]) Pop() interface{} {
 
 // buildMinPersistentHeapByInit will create a min-heap for distance metrics
 // in time O(n), where n = length of array
-func buildMinPersistentHeapByInit[T c.Float](array []minPersistentHeapElement[T]) *minPersistentTupleHeap[T] {
+func buildMinPersistentHeapByInit[T c.Float](array []persistentHeapElement[T]) *minPersistentTupleHeap[T] {
 	// initialize the MinTupleHeap that has implement the heap.Interface
 	minPersistentTupleHeap := &minPersistentTupleHeap[T]{}
 	*minPersistentTupleHeap = array
@@ -73,7 +73,7 @@ func buildMinPersistentHeapByInit[T c.Float](array []minPersistentHeapElement[T]
 
 // maxPersistentTupleHeap is a max-heap for similarity metrics (cosine, dot-product)
 // where higher values indicate better matches.
-type maxPersistentTupleHeap[T c.Float] []minPersistentHeapElement[T]
+type maxPersistentTupleHeap[T c.Float] []persistentHeapElement[T]
 
 func (h maxPersistentTupleHeap[T]) Len() int {
 	return len(h)
@@ -88,7 +88,7 @@ func (h maxPersistentTupleHeap[T]) Swap(i, j int) {
 }
 
 func (h *maxPersistentTupleHeap[T]) Push(x interface{}) {
-	*h = append(*h, x.(minPersistentHeapElement[T]))
+	*h = append(*h, x.(persistentHeapElement[T]))
 }
 
 func (h *maxPersistentTupleHeap[T]) PopLast() {
@@ -105,7 +105,7 @@ func (h *maxPersistentTupleHeap[T]) Pop() interface{} {
 
 // buildMaxPersistentHeapByInit will create a max-heap for similarity metrics
 // in time O(n), where n = length of array
-func buildMaxPersistentHeapByInit[T c.Float](array []minPersistentHeapElement[T]) *maxPersistentTupleHeap[T] {
+func buildMaxPersistentHeapByInit[T c.Float](array []persistentHeapElement[T]) *maxPersistentTupleHeap[T] {
 	maxHeap := &maxPersistentTupleHeap[T]{}
 	*maxHeap = array
 	heap.Init(maxHeap)
@@ -116,8 +116,8 @@ func buildMaxPersistentHeapByInit[T c.Float](array []minPersistentHeapElement[T]
 // It abstracts over min-heap (for distance metrics) and max-heap (for similarity metrics).
 type candidateHeap[T c.Float] interface {
 	Len() int
-	Push(x minPersistentHeapElement[T])
-	Pop() minPersistentHeapElement[T]
+	Push(x persistentHeapElement[T])
+	Pop() persistentHeapElement[T]
 	PopLast()
 }
 
@@ -130,12 +130,12 @@ func (w *minHeapWrapper[T]) Len() int {
 	return w.h.Len()
 }
 
-func (w *minHeapWrapper[T]) Push(x minPersistentHeapElement[T]) {
+func (w *minHeapWrapper[T]) Push(x persistentHeapElement[T]) {
 	heap.Push(w.h, x)
 }
 
-func (w *minHeapWrapper[T]) Pop() minPersistentHeapElement[T] {
-	return heap.Pop(w.h).(minPersistentHeapElement[T])
+func (w *minHeapWrapper[T]) Pop() persistentHeapElement[T] {
+	return heap.Pop(w.h).(persistentHeapElement[T])
 }
 
 func (w *minHeapWrapper[T]) PopLast() {
@@ -151,12 +151,12 @@ func (w *maxHeapWrapper[T]) Len() int {
 	return w.h.Len()
 }
 
-func (w *maxHeapWrapper[T]) Push(x minPersistentHeapElement[T]) {
+func (w *maxHeapWrapper[T]) Push(x persistentHeapElement[T]) {
 	heap.Push(w.h, x)
 }
 
-func (w *maxHeapWrapper[T]) Pop() minPersistentHeapElement[T] {
-	return heap.Pop(w.h).(minPersistentHeapElement[T])
+func (w *maxHeapWrapper[T]) Pop() persistentHeapElement[T] {
+	return heap.Pop(w.h).(persistentHeapElement[T])
 }
 
 func (w *maxHeapWrapper[T]) PopLast() {
@@ -165,7 +165,7 @@ func (w *maxHeapWrapper[T]) PopLast() {
 
 // buildCandidateHeap creates the appropriate heap based on whether we're using
 // a distance metric (lower is better) or similarity metric (higher is better).
-func buildCandidateHeap[T c.Float](array []minPersistentHeapElement[T], isSimilarityMetric bool) candidateHeap[T] {
+func buildCandidateHeap[T c.Float](array []persistentHeapElement[T], isSimilarityMetric bool) candidateHeap[T] {
 	if isSimilarityMetric {
 		return &maxHeapWrapper[T]{h: buildMaxPersistentHeapByInit(array)}
 	}

--- a/tok/hnsw/helper.go
+++ b/tok/hnsw/helper.go
@@ -114,8 +114,8 @@ func euclideanDistanceSq[T c.Float](a, b []T, floatBits int) (T, error) {
 
 // Used for distance, since shorter distance is better
 func insortPersistentHeapAscending[T c.Float](
-	slice []minPersistentHeapElement[T],
-	val minPersistentHeapElement[T]) []minPersistentHeapElement[T] {
+	slice []persistentHeapElement[T],
+	val persistentHeapElement[T]) []persistentHeapElement[T] {
 	i := sort.Search(len(slice), func(i int) bool { return slice[i].value > val.value })
 	var empty T
 	slice = append(slice, *initPersistentHeapElement(empty, notAUid, false))
@@ -126,8 +126,8 @@ func insortPersistentHeapAscending[T c.Float](
 
 // Used for cosine similarity, since higher similarity score is better
 func insortPersistentHeapDescending[T c.Float](
-	slice []minPersistentHeapElement[T],
-	val minPersistentHeapElement[T]) []minPersistentHeapElement[T] {
+	slice []persistentHeapElement[T],
+	val persistentHeapElement[T]) []persistentHeapElement[T] {
 	i := sort.Search(len(slice), func(i int) bool { return slice[i].value < val.value })
 	var empty T
 	slice = append(slice, *initPersistentHeapElement(empty, notAUid, false))
@@ -206,7 +206,7 @@ func cannotConvertToUintSlice(s string) error {
 type SimilarityType[T c.Float] struct {
 	indexType     string
 	distanceScore func(v, w []T, floatBits int) (T, error)
-	insortHeap    func(slice []minPersistentHeapElement[T], val minPersistentHeapElement[T]) []minPersistentHeapElement[T]
+	insortHeap    func(slice []persistentHeapElement[T], val persistentHeapElement[T]) []persistentHeapElement[T]
 	isBetterScore func(a, b T) bool
 	// isSimilarityMetric is true for metrics where higher values indicate better matches
 	// (e.g., cosine similarity, dot product). For distance metrics like euclidean,

--- a/tok/hnsw/persistent_hnsw_test.go
+++ b/tok/hnsw/persistent_hnsw_test.go
@@ -553,7 +553,7 @@ func TestBasicSearchPersistentFlatStorage(t *testing.T) {
 // TestCandidateHeapMinHeap verifies that the min-heap (for distance metrics like euclidean)
 // pops elements in ascending order (smallest first).
 func TestCandidateHeapMinHeap(t *testing.T) {
-	elements := []minPersistentHeapElement[float64]{
+	elements := []persistentHeapElement[float64]{
 		{value: 0.5, index: 1},
 		{value: 0.1, index: 2},
 		{value: 0.9, index: 3},
@@ -583,7 +583,7 @@ func TestCandidateHeapMinHeap(t *testing.T) {
 // TestCandidateHeapMaxHeap verifies that the max-heap (for similarity metrics like cosine)
 // pops elements in descending order (largest first).
 func TestCandidateHeapMaxHeap(t *testing.T) {
-	elements := []minPersistentHeapElement[float64]{
+	elements := []persistentHeapElement[float64]{
 		{value: 0.5, index: 1},
 		{value: 0.1, index: 2},
 		{value: 0.9, index: 3},
@@ -613,11 +613,11 @@ func TestCandidateHeapMaxHeap(t *testing.T) {
 // TestCandidateHeapPushPop verifies that Push and Pop work correctly for both heap types.
 func TestCandidateHeapPushPop(t *testing.T) {
 	t.Run("MinHeap", func(t *testing.T) {
-		heap := buildCandidateHeap([]minPersistentHeapElement[float64]{}, false)
+		heap := buildCandidateHeap([]persistentHeapElement[float64]{}, false)
 
-		heap.Push(minPersistentHeapElement[float64]{value: 0.5, index: 1})
-		heap.Push(minPersistentHeapElement[float64]{value: 0.2, index: 2})
-		heap.Push(minPersistentHeapElement[float64]{value: 0.8, index: 3})
+		heap.Push(persistentHeapElement[float64]{value: 0.5, index: 1})
+		heap.Push(persistentHeapElement[float64]{value: 0.2, index: 2})
+		heap.Push(persistentHeapElement[float64]{value: 0.8, index: 3})
 
 		// Min-heap should pop smallest first
 		elem := heap.Pop()
@@ -635,11 +635,11 @@ func TestCandidateHeapPushPop(t *testing.T) {
 	})
 
 	t.Run("MaxHeap", func(t *testing.T) {
-		heap := buildCandidateHeap([]minPersistentHeapElement[float64]{}, true)
+		heap := buildCandidateHeap([]persistentHeapElement[float64]{}, true)
 
-		heap.Push(minPersistentHeapElement[float64]{value: 0.5, index: 1})
-		heap.Push(minPersistentHeapElement[float64]{value: 0.2, index: 2})
-		heap.Push(minPersistentHeapElement[float64]{value: 0.8, index: 3})
+		heap.Push(persistentHeapElement[float64]{value: 0.5, index: 1})
+		heap.Push(persistentHeapElement[float64]{value: 0.2, index: 2})
+		heap.Push(persistentHeapElement[float64]{value: 0.8, index: 3})
 
 		// Max-heap should pop largest first
 		elem := heap.Pop()

--- a/tok/hnsw/search_layer.go
+++ b/tok/hnsw/search_layer.go
@@ -14,9 +14,9 @@ import (
 
 type searchLayerResult[T c.Float] struct {
 	// neighbors represents the candidates with the best scores so far.
-	neighbors []minPersistentHeapElement[T]
+	neighbors []persistentHeapElement[T]
 	// visited represents elements seen (so we don't try to re-visit).
-	visited map[uint64]minPersistentHeapElement[T]
+	visited map[uint64]persistentHeapElement[T]
 	path    []uint64
 	metrics map[string]uint64
 	level   int
@@ -33,23 +33,23 @@ type searchLayerResult[T c.Float] struct {
 
 func newLayerResult[T c.Float](level int) *searchLayerResult[T] {
 	return &searchLayerResult[T]{
-		neighbors: []minPersistentHeapElement[T]{},
-		visited:   make(map[uint64]minPersistentHeapElement[T]),
+		neighbors: []persistentHeapElement[T]{},
+		visited:   make(map[uint64]persistentHeapElement[T]),
 		path:      []uint64{},
 		metrics:   make(map[string]uint64),
 		level:     level,
 	}
 }
 
-func (slr *searchLayerResult[T]) setFirstPathNode(n minPersistentHeapElement[T]) {
-	slr.neighbors = []minPersistentHeapElement[T]{n}
-	slr.visited = make(map[uint64]minPersistentHeapElement[T])
+func (slr *searchLayerResult[T]) setFirstPathNode(n persistentHeapElement[T]) {
+	slr.neighbors = []persistentHeapElement[T]{n}
+	slr.visited = make(map[uint64]persistentHeapElement[T])
 	slr.visited[n.index] = n
 	slr.path = []uint64{n.index}
 }
 
 func (slr *searchLayerResult[T]) addPathNode(
-	n minPersistentHeapElement[T],
+	n persistentHeapElement[T],
 	simType SimilarityType[T],
 	maxResults int) {
 	slr.neighbors = simType.insortHeap(slr.neighbors, n)
@@ -80,7 +80,7 @@ func (slr *searchLayerResult[T]) incrementDistanceComputations() {
 
 // slr.lastNeighborScore() returns the "score" (based on similarity type)
 // of the last neighbor being tracked. The score is reflected as a value
-// of the minPersistentHeapElement.
+// of the persistentHeapElement.
 // If slr is empty, this will panic.
 func (slr *searchLayerResult[T]) lastNeighborScore() T {
 	return slr.neighbors[len(slr.neighbors)-1].value
@@ -88,7 +88,7 @@ func (slr *searchLayerResult[T]) lastNeighborScore() T {
 
 // slr.bestNeighbor() returns the heap element with the "best" score.
 // panics if there is no such element.
-func (slr *searchLayerResult[T]) bestNeighbor() minPersistentHeapElement[T] {
+func (slr *searchLayerResult[T]) bestNeighbor() persistentHeapElement[T] {
 	return slr.neighbors[0]
 }
 
@@ -97,7 +97,7 @@ func (slr *searchLayerResult[T]) indexVisited(n uint64) bool {
 	return ok
 }
 
-func (slr *searchLayerResult[T]) addToVisited(n minPersistentHeapElement[T]) {
+func (slr *searchLayerResult[T]) addToVisited(n persistentHeapElement[T]) {
 	slr.visited[n.index] = n
 }
 


### PR DESCRIPTION
### Summary

This PR fixes a critical bug in HNSW vector search where **cosine similarity and dot product metrics returned incorrect results**. The search algorithm was treating all metrics as distance metrics (lower is better), causing similarity metrics (higher is better) to return the *worst* matches instead of the best.

This PR also brings in a number of optimizations from @joelamming in PR #9563 that optimized construction pruning.

### Problem

The HNSW implementation had two issues with similarity-based metrics:

1. **Search phase**: The candidate heap in persistent_hnsw.go::searchPersistentLayer always used a min-heap, which pops the lowest value first. For similarity metrics where higher values are better, this caused the algorithm to explore the worst candidates first and terminate prematurely.

2. **Edge pruning phase**: The helper.go::addNeighbors function used a fixed comparison (`>`) when pruning edges, which is correct for distance metrics but inverted for similarity metrics. This resulted in keeping the worst edges instead of the best.

### Root Cause

The original code assumed all metrics behave like distance metrics:

```go
// Always used min-heap (pops lowest first)
candidateHeap := *buildPersistentHeapByInit(elements)

// Edge pruning always used > comparison
compare: func(i, j uint64) bool {
    return ph.distance_betw(..., i, ...) > ph.distance_betw(..., j, ...)
}
```

For **Euclidean distance**, lower values = better matches → min-heap is correct.
For **Cosine/DotProduct similarity**, higher values = better matches → need max-heap.

### Solution

#### 1. Added candidateHeap interface with metric-aware heap selection

```go
type candidateHeap[T c.Float] interface {
    Len() int
    Pop() minPersistentHeapElement[T]
    Push(minPersistentHeapElement[T])
    PopLast() minPersistentHeapElement[T]
}

func buildCandidateHeap[T c.Float](array []minPersistentHeapElement[T], isSimilarityMetric bool) candidateHeap[T] {
    if isSimilarityMetric {
        return &maxHeapWrapper[T]{...}  // Pops highest first
    }
    return &minHeapWrapper[T]{...}      // Pops lowest first
}
```

#### 2. Added isSimilarityMetric flag to SimilarityType

```go
type SimilarityType[T c.Float] struct {
    // ... existing fields
    isSimilarityMetric bool  // true for cosine, dotproduct; false for euclidean
}
```

#### 3. Fixed edge pruning comparison in addNeighbors

```go
compare: func(i, j uint64) bool {
    distI := ph.distance_betw(ctx, tc, uuid, i, &inVec, &outVec)
    distJ := ph.distance_betw(ctx, tc, uuid, j, &inVec, &outVec)
    return !ph.simType.isBetterScore(distI, distJ)
}
```

### Files Changed

| File | Changes |
|------|---------|
| tok/hnsw/heap.go | Added candidateHeap interface, minHeapWrapper, maxHeapWrapper, and buildCandidateHeap factory |
| tok/hnsw/helper.go | Added isSimilarityMetric field to SimilarityType; fixed edge pruning comparison |
| tok/hnsw/persistent_hnsw.go | Updated searchPersistentLayer to use metric-aware candidate heap |
| tok/hnsw/persistent_hnsw_test.go | Added comprehensive unit tests for heap behavior and search correctness |

### Testing

Added new tests covering:

- TestCandidateHeapMinHeap: Verifies min-heap pops in ascending order
- TestCandidateHeapMaxHeap: Verifies max-heap pops in descending order
- TestCandidateHeapPushPop: Tests Push/Pop operations for both heap types
- TestCandidateHeapPopLast: Tests PopLast for both types
- TestSimilarityTypeIsSimilarityMetric: Verifies flag is set correctly for each metric
- TestSearchReturnsCorrectOrderForAllMetrics: End-to-end test for Euclidean, Cosine, and DotProduct
- TestEdgePruningKeepsBestEdges: Verifies edge pruning keeps best edges for each metric

### Performance Note

This fix builds on PR #9514 which corrected the early termination condition. Together, these changes ensure HNSW search explores the correct number of candidates and returns properly ordered results.

Users experiencing slower insert/search times compared to v25.1.0 can tune performance by lowering efConstruction and efSearch parameters when creating your vector indexes.

Lower values trade recall for speed. The default values (efConstruction=128, efSearch=64) prioritize recall.

### GenAI Notice

Parts of this implementation and all of the testing was generated using Claude Opus 4.5 (thinking).

### Checklist

- [x] The PR title follows the
      [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax, leading
      with `fix:`, `feat:`, `chore:`, `ci:`, etc.
- [x] Code compiles correctly and linting (via trunk) passes locally
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable

Fixes #9558

### Benchmarks

Our BEIR SciFact Information Retrieval Benchmarks now show recall rates close to or exceeding acceptable and excellent performance for all metrics.

```
============================================================================================================================================
NDCG@k Comparison
============================================================================================================================================

NDCG@1:
--------------------------------------------------------------------------------------------------------------------------------------------
  BEIR Excellent (State-of-the-art baseline (768-dim)) ██████████████████░░░░░░░░░░░░ 0.6200
  BEIR Acceptable (Acceptable baseline (384-dim))      ███████████████░░░░░░░░░░░░░░░ 0.5200
  Dgraph v25.1.0 (euclidean)                           ███████████████░░░░░░░░░░░░░░░ 0.5000
  Dgraph v25.1.0 (cosine)                              ████████░░░░░░░░░░░░░░░░░░░░░░ 0.2767
  Dgraph v25.1.0 (dotproduct)                          ████████░░░░░░░░░░░░░░░░░░░░░░ 0.2867
  Dgraph staged-fix (euclidean)                        ███████████████░░░░░░░░░░░░░░░ 0.5233
  Dgraph staged-fix (cosine)                           ███████████████░░░░░░░░░░░░░░░ 0.5300
  Dgraph staged-fix (dotproduct)                       ███████████████░░░░░░░░░░░░░░░ 0.5167

NDCG@3:
--------------------------------------------------------------------------------------------------------------------------------------------
  BEIR Excellent (State-of-the-art baseline (768-dim)) ████████████████████░░░░░░░░░░ 0.6700
  BEIR Acceptable (Acceptable baseline (384-dim))      ██████████████████░░░░░░░░░░░░ 0.6000
  Dgraph v25.1.0 (euclidean)                           ████████████████░░░░░░░░░░░░░░ 0.5588
  Dgraph v25.1.0 (cosine)                              █████████░░░░░░░░░░░░░░░░░░░░░ 0.3043
  Dgraph v25.1.0 (dotproduct)                          █████████░░░░░░░░░░░░░░░░░░░░░ 0.3164
  Dgraph staged-fix (euclidean)                        █████████████████░░░░░░░░░░░░░ 0.5918
  Dgraph staged-fix (cosine)                           █████████████████░░░░░░░░░░░░░ 0.5957
  Dgraph staged-fix (dotproduct)                       █████████████████░░░░░░░░░░░░░ 0.5830

NDCG@5:
--------------------------------------------------------------------------------------------------------------------------------------------
  BEIR Excellent (State-of-the-art baseline (768-dim)) ████████████████████░░░░░░░░░░ 0.6900
  BEIR Acceptable (Acceptable baseline (384-dim))      ██████████████████░░░░░░░░░░░░ 0.6300
  Dgraph v25.1.0 (euclidean)                           █████████████████░░░░░░░░░░░░░ 0.5858
  Dgraph v25.1.0 (cosine)                              █████████░░░░░░░░░░░░░░░░░░░░░ 0.3197
  Dgraph v25.1.0 (dotproduct)                          █████████░░░░░░░░░░░░░░░░░░░░░ 0.3290
  Dgraph staged-fix (euclidean)                        ██████████████████░░░░░░░░░░░░ 0.6168
  Dgraph staged-fix (cosine)                           ██████████████████░░░░░░░░░░░░ 0.6240
  Dgraph staged-fix (dotproduct)                       ██████████████████░░░░░░░░░░░░ 0.6081

NDCG@10:
--------------------------------------------------------------------------------------------------------------------------------------------
  BEIR Excellent (State-of-the-art baseline (768-dim)) █████████████████████░░░░░░░░░ 0.7000
  BEIR Acceptable (Acceptable baseline (384-dim))      ███████████████████░░░░░░░░░░░ 0.6500
  Dgraph v25.1.0 (euclidean)                           ██████████████████░░░░░░░░░░░░ 0.6118
  Dgraph v25.1.0 (cosine)                              █████████░░░░░░░░░░░░░░░░░░░░░ 0.3305
  Dgraph v25.1.0 (dotproduct)                          ██████████░░░░░░░░░░░░░░░░░░░░ 0.3423
  Dgraph staged-fix (euclidean)                        ███████████████████░░░░░░░░░░░ 0.6461
  Dgraph staged-fix (cosine)                           ███████████████████░░░░░░░░░░░ 0.6505
  Dgraph staged-fix (dotproduct)                       ███████████████████░░░░░░░░░░░ 0.6369

NDCG@100:
--------------------------------------------------------------------------------------------------------------------------------------------
  BEIR Excellent (State-of-the-art baseline (768-dim)) █████████████████████░░░░░░░░░ 0.7200
  BEIR Acceptable (Acceptable baseline (384-dim))      ████████████████████░░░░░░░░░░ 0.6800
  Dgraph v25.1.0 (euclidean)                           ███████████████████░░░░░░░░░░░ 0.6418
  Dgraph v25.1.0 (cosine)                              ██████████░░░░░░░░░░░░░░░░░░░░ 0.3445
  Dgraph v25.1.0 (dotproduct)                          ██████████░░░░░░░░░░░░░░░░░░░░ 0.3555
  Dgraph staged-fix (euclidean)                        ████████████████████░░░░░░░░░░ 0.6794
  Dgraph staged-fix (cosine)                           ████████████████████░░░░░░░░░░ 0.6849
  Dgraph staged-fix (dotproduct)                       ████████████████████░░░░░░░░░░ 0.6707

============================================================================================================================================
MAP@k Comparison
============================================================================================================================================

MAP@1:
--------------------------------------------------------------------------------------------------------------------------------------------
  BEIR Excellent (State-of-the-art baseline (768-dim)) ██████████████████░░░░░░░░░░░░ 0.6000
  BEIR Acceptable (Acceptable baseline (384-dim))      ███████████████░░░░░░░░░░░░░░░ 0.5000
  Dgraph v25.1.0 (euclidean)                           ██████████████░░░░░░░░░░░░░░░░ 0.4812
  Dgraph v25.1.0 (cosine)                              ███████░░░░░░░░░░░░░░░░░░░░░░░ 0.2586
  Dgraph v25.1.0 (dotproduct)                          ████████░░░░░░░░░░░░░░░░░░░░░░ 0.2747
  Dgraph staged-fix (euclidean)                        ███████████████░░░░░░░░░░░░░░░ 0.5046
  Dgraph staged-fix (cosine)                           ███████████████░░░░░░░░░░░░░░░ 0.5112
  Dgraph staged-fix (dotproduct)                       ██████████████░░░░░░░░░░░░░░░░ 0.4979

MAP@3:
--------------------------------------------------------------------------------------------------------------------------------------------
  BEIR Excellent (State-of-the-art baseline (768-dim)) ███████████████████░░░░░░░░░░░ 0.6400
  BEIR Acceptable (Acceptable baseline (384-dim))      █████████████████░░░░░░░░░░░░░ 0.5700
  Dgraph v25.1.0 (euclidean)                           ████████████████░░░░░░░░░░░░░░ 0.5357
  Dgraph v25.1.0 (cosine)                              ████████░░░░░░░░░░░░░░░░░░░░░░ 0.2883
  Dgraph v25.1.0 (dotproduct)                          █████████░░░░░░░░░░░░░░░░░░░░░ 0.3022
  Dgraph staged-fix (euclidean)                        ████████████████░░░░░░░░░░░░░░ 0.5663
  Dgraph staged-fix (cosine)                           █████████████████░░░░░░░░░░░░░ 0.5707
  Dgraph staged-fix (dotproduct)                       ████████████████░░░░░░░░░░░░░░ 0.5579

MAP@5:
--------------------------------------------------------------------------------------------------------------------------------------------
  BEIR Excellent (State-of-the-art baseline (768-dim)) ███████████████████░░░░░░░░░░░ 0.6600
  BEIR Acceptable (Acceptable baseline (384-dim))      █████████████████░░░░░░░░░░░░░ 0.5900
  Dgraph v25.1.0 (euclidean)                           ████████████████░░░░░░░░░░░░░░ 0.5544
  Dgraph v25.1.0 (cosine)                              ████████░░░░░░░░░░░░░░░░░░░░░░ 0.2993
  Dgraph v25.1.0 (dotproduct)                          █████████░░░░░░░░░░░░░░░░░░░░░ 0.3113
  Dgraph staged-fix (euclidean)                        █████████████████░░░░░░░░░░░░░ 0.5838
  Dgraph staged-fix (cosine)                           █████████████████░░░░░░░░░░░░░ 0.5902
  Dgraph staged-fix (dotproduct)                       █████████████████░░░░░░░░░░░░░ 0.5755

MAP@10:
--------------------------------------------------------------------------------------------------------------------------------------------
  BEIR Excellent (State-of-the-art baseline (768-dim)) ████████████████████░░░░░░░░░░ 0.6700
  BEIR Acceptable (Acceptable baseline (384-dim))      ██████████████████░░░░░░░░░░░░ 0.6000
  Dgraph v25.1.0 (euclidean)                           █████████████████░░░░░░░░░░░░░ 0.5676
  Dgraph v25.1.0 (cosine)                              █████████░░░░░░░░░░░░░░░░░░░░░ 0.3045
  Dgraph v25.1.0 (dotproduct)                          █████████░░░░░░░░░░░░░░░░░░░░░ 0.3175
  Dgraph staged-fix (euclidean)                        █████████████████░░░░░░░░░░░░░ 0.5987
  Dgraph staged-fix (cosine)                           ██████████████████░░░░░░░░░░░░ 0.6035
  Dgraph staged-fix (dotproduct)                       █████████████████░░░░░░░░░░░░░ 0.5900

MAP@100:
--------------------------------------------------------------------------------------------------------------------------------------------
  BEIR Excellent (State-of-the-art baseline (768-dim)) ████████████████████░░░░░░░░░░ 0.6800
  BEIR Acceptable (Acceptable baseline (384-dim))      ██████████████████░░░░░░░░░░░░ 0.6100
  Dgraph v25.1.0 (euclidean)                           █████████████████░░░░░░░░░░░░░ 0.5746
  Dgraph v25.1.0 (cosine)                              █████████░░░░░░░░░░░░░░░░░░░░░ 0.3074
  Dgraph v25.1.0 (dotproduct)                          █████████░░░░░░░░░░░░░░░░░░░░░ 0.3203
  Dgraph staged-fix (euclidean)                        ██████████████████░░░░░░░░░░░░ 0.6060
  Dgraph staged-fix (cosine)                           ██████████████████░░░░░░░░░░░░ 0.6113
  Dgraph staged-fix (dotproduct)                       █████████████████░░░░░░░░░░░░░ 0.5977

============================================================================================================================================
RECALL@k Comparison
============================================================================================================================================

Recall@1:
--------------------------------------------------------------------------------------------------------------------------------------------
  BEIR Excellent (State-of-the-art baseline (768-dim)) ██████████████████░░░░░░░░░░░░ 0.6000
  BEIR Acceptable (Acceptable baseline (384-dim))      ███████████████░░░░░░░░░░░░░░░ 0.5000
  Dgraph v25.1.0 (euclidean)                           ██████████████░░░░░░░░░░░░░░░░ 0.4812
  Dgraph v25.1.0 (cosine)                              ███████░░░░░░░░░░░░░░░░░░░░░░░ 0.2586
  Dgraph v25.1.0 (dotproduct)                          ████████░░░░░░░░░░░░░░░░░░░░░░ 0.2747
  Dgraph staged-fix (euclidean)                        ███████████████░░░░░░░░░░░░░░░ 0.5046
  Dgraph staged-fix (cosine)                           ███████████████░░░░░░░░░░░░░░░ 0.5112
  Dgraph staged-fix (dotproduct)                       ██████████████░░░░░░░░░░░░░░░░ 0.4979

Recall@3:
--------------------------------------------------------------------------------------------------------------------------------------------
  BEIR Excellent (State-of-the-art baseline (768-dim)) █████████████████████░░░░░░░░░ 0.7300
  BEIR Acceptable (Acceptable baseline (384-dim))      ███████████████████░░░░░░░░░░░ 0.6500
  Dgraph v25.1.0 (euclidean)                           █████████████████░░░░░░░░░░░░░ 0.5984
  Dgraph v25.1.0 (cosine)                              █████████░░░░░░░░░░░░░░░░░░░░░ 0.3248
  Dgraph v25.1.0 (dotproduct)                          ██████████░░░░░░░░░░░░░░░░░░░░ 0.3377
  Dgraph staged-fix (euclidean)                        ███████████████████░░░░░░░░░░░ 0.6384
  Dgraph staged-fix (cosine)                           ███████████████████░░░░░░░░░░░ 0.6401
  Dgraph staged-fix (dotproduct)                       ██████████████████░░░░░░░░░░░░ 0.6284

Recall@5:
--------------------------------------------------------------------------------------------------------------------------------------------
  BEIR Excellent (State-of-the-art baseline (768-dim)) ███████████████████████░░░░░░░ 0.7900
  BEIR Acceptable (Acceptable baseline (384-dim))      █████████████████████░░░░░░░░░ 0.7200
  Dgraph v25.1.0 (euclidean)                           ███████████████████░░░░░░░░░░░ 0.6638
  Dgraph v25.1.0 (cosine)                              ██████████░░░░░░░░░░░░░░░░░░░░ 0.3632
  Dgraph v25.1.0 (dotproduct)                          ███████████░░░░░░░░░░░░░░░░░░░ 0.3697
  Dgraph staged-fix (euclidean)                        ████████████████████░░░░░░░░░░ 0.6988
  Dgraph staged-fix (cosine)                           █████████████████████░░░░░░░░░ 0.7088
  Dgraph staged-fix (dotproduct)                       ████████████████████░░░░░░░░░░ 0.6888

Recall@10:
--------------------------------------------------------------------------------------------------------------------------------------------
  BEIR Excellent (State-of-the-art baseline (768-dim)) █████████████████████████░░░░░ 0.8400
  BEIR Acceptable (Acceptable baseline (384-dim))      ███████████████████████░░░░░░░ 0.7800
  Dgraph v25.1.0 (euclidean)                           ██████████████████████░░░░░░░░ 0.7368
  Dgraph v25.1.0 (cosine)                              ███████████░░░░░░░░░░░░░░░░░░░ 0.3950
  Dgraph v25.1.0 (dotproduct)                          ████████████░░░░░░░░░░░░░░░░░░ 0.4074
  Dgraph staged-fix (euclidean)                        ███████████████████████░░░░░░░ 0.7808
  Dgraph staged-fix (cosine)                           ███████████████████████░░░░░░░ 0.7834
  Dgraph staged-fix (dotproduct)                       ███████████████████████░░░░░░░ 0.7701

Recall@100:
--------------------------------------------------------------------------------------------------------------------------------------------
  BEIR Excellent (State-of-the-art baseline (768-dim)) ████████████████████████████░░ 0.9500
  BEIR Acceptable (Acceptable baseline (384-dim))      ███████████████████████████░░░ 0.9000
  Dgraph v25.1.0 (euclidean)                           ██████████████████████████░░░░ 0.8717
  Dgraph v25.1.0 (cosine)                              █████████████░░░░░░░░░░░░░░░░░ 0.4589
  Dgraph v25.1.0 (dotproduct)                          █████████████░░░░░░░░░░░░░░░░░ 0.4658
  Dgraph staged-fix (euclidean)                        ████████████████████████████░░ 0.9350
  Dgraph staged-fix (cosine)                           ████████████████████████████░░ 0.9417
  Dgraph staged-fix (dotproduct)                       ███████████████████████████░░░ 0.9250

============================================================================================================================================
PRECISION@k Comparison
============================================================================================================================================

Precision@1:
--------------------------------------------------------------------------------------------------------------------------------------------
  BEIR Excellent (State-of-the-art baseline (768-dim)) ██████████████████░░░░░░░░░░░░ 0.6200
  BEIR Acceptable (Acceptable baseline (384-dim))      ███████████████░░░░░░░░░░░░░░░ 0.5200
  Dgraph v25.1.0 (euclidean)                           ███████████████░░░░░░░░░░░░░░░ 0.5000
  Dgraph v25.1.0 (cosine)                              ████████░░░░░░░░░░░░░░░░░░░░░░ 0.2767
  Dgraph v25.1.0 (dotproduct)                          ████████░░░░░░░░░░░░░░░░░░░░░░ 0.2867
  Dgraph staged-fix (euclidean)                        ███████████████░░░░░░░░░░░░░░░ 0.5233
  Dgraph staged-fix (cosine)                           ███████████████░░░░░░░░░░░░░░░ 0.5300
  Dgraph staged-fix (dotproduct)                       ███████████████░░░░░░░░░░░░░░░ 0.5167

Precision@3:
--------------------------------------------------------------------------------------------------------------------------------------------
  BEIR Excellent (State-of-the-art baseline (768-dim)) ██████████████████████████████ 0.2700
  BEIR Acceptable (Acceptable baseline (384-dim))      █████████████████████████░░░░░ 0.2300
  Dgraph v25.1.0 (euclidean)                           ████████████████████████░░░░░░ 0.2178
  Dgraph v25.1.0 (cosine)                              █████████████░░░░░░░░░░░░░░░░░ 0.1211
  Dgraph v25.1.0 (dotproduct)                          █████████████░░░░░░░░░░░░░░░░░ 0.1211
  Dgraph staged-fix (euclidean)                        █████████████████████████░░░░░ 0.2311
  Dgraph staged-fix (cosine)                           █████████████████████████░░░░░ 0.2322
  Dgraph staged-fix (dotproduct)                       █████████████████████████░░░░░ 0.2278

Precision@5:
--------------------------------------------------------------------------------------------------------------------------------------------
  BEIR Excellent (State-of-the-art baseline (768-dim)) ██████████████████████████████ 0.1800
  BEIR Acceptable (Acceptable baseline (384-dim))      ██████████████████████████░░░░ 0.1600
  Dgraph v25.1.0 (euclidean)                           ████████████████████████░░░░░░ 0.1480
  Dgraph v25.1.0 (cosine)                              █████████████░░░░░░░░░░░░░░░░░ 0.0827
  Dgraph v25.1.0 (dotproduct)                          █████████████░░░░░░░░░░░░░░░░░ 0.0807
  Dgraph staged-fix (euclidean)                        █████████████████████████░░░░░ 0.1553
  Dgraph staged-fix (cosine)                           ██████████████████████████░░░░ 0.1573
  Dgraph staged-fix (dotproduct)                       █████████████████████████░░░░░ 0.1533

Precision@10:
--------------------------------------------------------------------------------------------------------------------------------------------
  BEIR Excellent (State-of-the-art baseline (768-dim)) ██████████████████████████████ 0.1000
  BEIR Acceptable (Acceptable baseline (384-dim))      ██████████████████████████░░░░ 0.0900
  Dgraph v25.1.0 (euclidean)                           █████████████████████████░░░░░ 0.0837
  Dgraph v25.1.0 (cosine)                              █████████████░░░░░░░░░░░░░░░░░ 0.0453
  Dgraph v25.1.0 (dotproduct)                          █████████████░░░░░░░░░░░░░░░░░ 0.0447
  Dgraph staged-fix (euclidean)                        ██████████████████████████░░░░ 0.0887
  Dgraph staged-fix (cosine)                           ██████████████████████████░░░░ 0.0887
  Dgraph staged-fix (dotproduct)                       ██████████████████████████░░░░ 0.0873

Precision@100:
--------------------------------------------------------------------------------------------------------------------------------------------
  BEIR Excellent (State-of-the-art baseline (768-dim)) ████████████████████████████░░ 0.0100
  BEIR Acceptable (Acceptable baseline (384-dim))      ████████████████████████████░░ 0.0100
  Dgraph v25.1.0 (euclidean)                           ███████████████████████████░░░ 0.0100
  Dgraph v25.1.0 (cosine)                              ██████████████░░░░░░░░░░░░░░░░ 0.0053
  Dgraph v25.1.0 (dotproduct)                          ██████████████░░░░░░░░░░░░░░░░ 0.0051
  Dgraph staged-fix (euclidean)                        █████████████████████████████░ 0.0106
  Dgraph staged-fix (cosine)                           ██████████████████████████████ 0.0107
  Dgraph staged-fix (dotproduct)                       █████████████████████████████░ 0.0105
```
