### PR TITLE
fix(vector): Make construction pruning deterministic and align tests

### DIFF
--- a/tok/hnsw/persistent_hnsw_test.go
+++ b/tok/hnsw/persistent_hnsw_test.go
@@ -730,7 +730,8 @@ func TestEdgePruningKeepsBestNeighbors(t *testing.T) {
 				scoreMap[uids[i]] = score
 			}
 
-			keptUids := pruneUidsByScore(uids, tc.keepCount, simType, scoreMap)
+			scoreFn := func(uid uint64) float64 { return scoreMap[uid] }
+			keptUids := insertUidsTopKByScore(nil, uids, tc.keepCount, simType, scoreFn)
 			// Check that the remaining elements are the best ones
 			keptScores := make([]float64, len(keptUids))
 			for i, uid := range keptUids {


### PR DESCRIPTION
**Description**

This PR is a small follow-up to @matthewmcneely's `matthewmcneely/fix-similarity-based-hnsw-indexing` that tightens the construction-time pruning path in `tok/hnsw/helper.go:addNeighbors`.

- Makes construction pruning explicitly maintain the best-to-worst top‑k neighbour list capped at `efConstruction` (rather than relying on heap/slice side-effects)
- Avoids duplicate/self edges during construction updates
- Aligns the pruning unit test with the same helper used by production to reduce test/production drift

This is intended to be easy to cherrypick into the [PR branch](https://github.com/dgraph-io/dgraph/pull/9559)

### Why
The directionality fix is the key part (and @matthewmcneely's [PR](https://github.com/dgraph-io/dgraph/pull/9559) nails that), but the existing pruning loop still had a couple of structure-level issues (heap initialisation/slice truncation semantics) that could make construction behaviour hard to reason about -- especially under similarity metrics

### Testing
- `go test ./tok/hnsw -count=1`
- Synthetic recall harness (25k vectors) shows massively improved recall vs. `main` (per my [comment](https://github.com/dgraph-io/dgraph/pull/9559#issuecomment-3733636238)) and stable miss-rate and expected build/query behaviour vs. https://github.com/dgraph-io/dgraph/pull/9559

**Checklist**

- [x] The PR title follows the
      [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax, leading
      with `fix:`, `feat:`, `chore:`, `ci:`, etc.
- [x] Code compiles correctly and linting (via trunk) passes locally
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable