### PR TITLE
docs: fix typos in comments

### DIFF
--- a/dql/parser.go
+++ b/dql/parser.go
@@ -1232,7 +1232,7 @@ func getSchema(it *lex.ItemIterator) (*pb.SchemaRequest, error) {
 	return nil, it.Errorf("Invalid schema block.")
 }
 
-// parseDqlVariables parses the the DQL variable declaration.
+// parseDqlVariables parses the DQL variable declaration.
 func parseDqlVariables(it *lex.ItemIterator, vmap varMap) error {
 	expectArg := true
 	if item, ok := it.PeekOne(); ok && item.Typ == itemRightRound {
@@ -1824,7 +1824,7 @@ L:
 					function.Attr = nestedFunc.Attr
 					function.IsCount = true
 				case uidFunc:
-					// TODO (Anurag): See if is is possible to support uid(1,2,3) when
+					// TODO (Anurag): See if it is possible to support uid(1,2,3) when
 					// uid is nested inside a function like @filter(uid_in(predicate, uid()))
 					if len(nestedFunc.NeedsVar) != 1 {
 						return nil,

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -1321,7 +1321,7 @@ func asIDReference(
 //
 // Currently adds enforce the schema ! restrictions, but updates don't.
 // e.g. a Post might have `title: String!“ in the schema, but,  a Post update could
-// set that to to null. ATM we allow this and it'll just triggers GraphQL error propagation
+// set that to null. ATM we allow this and it'll just triggers GraphQL error propagation
 // when that is in a query result.  This is the same case as deletes: e.g. deleting
 // an author might make the `author: Author!` field of a bunch of Posts invalid.
 // (That might actually be helpful if you want to run one mutation to remove something

--- a/lex/lexer.go
+++ b/lex/lexer.go
@@ -99,7 +99,7 @@ func (p *ItemIterator) Prev() bool {
 	return false
 }
 
-// Restore restores the the iterator to position specified.
+// Restore restores the iterator to position specified.
 func (p *ItemIterator) Restore(pos int) {
 	x.AssertTrue(pos <= len(p.l.items) && pos >= -1)
 	p.idx = pos

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -647,7 +647,7 @@ func intersectBucket(ctx context.Context, ts *pb.SortMessage, token string,
 
 		// We are within the page. We need to apply sorting.
 		// Sort results by value before applying offset.
-		// TODO (pawan) - Why do we do this? Looks like it it is only useful for language.
+		// TODO (pawan) - Why do we do this? Looks like it is only useful for language.
 		if vals, err = sortByValue(ctx, ts, result, scalar); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

Fix duplicated word typos in comments:

- `the the` → `the`
- `is is` → `it is`
- `to to` → `to`
- `it it` → `it`

## Files Changed

- dql/parser.go
- lex/lexer.go
- graphql/resolve/mutation_rewriter.go
- worker/sort.go