### PR TITLE
fix(ci): update trunk go runtime to match go.mod version

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -14,7 +14,7 @@ plugins:
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
   enabled:
-    - go@1.24.3
+    - go@1.25.6
     - node@22.16.0
     - python@3.10.8
 


### PR DESCRIPTION
## Summary

- Updates trunk's Go runtime from `1.24.3` to `1.25.6` to match the `go.mod` version

## Context

Commit 5bc29255a updated `go.mod` to Go 1.25.6, but the trunk runtime configuration was not updated. This causes the Trunk Code Quality CI check to fail with:

```
Error: can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.6)
```

## Test plan

- [x] Verified `trunk check` passes locally after the change