### PR TITLE
chore(ci): enable manual trigger for ci-dgraph-jepsen-tests

### DIFF
--- a/.github/workflows/ci-dgraph-jepsen-tests.yml
+++ b/.github/workflows/ci-dgraph-jepsen-tests.yml
@@ -1,6 +1,7 @@
 name: ci-dgraph-jepsen-tests
 
 on:
+  workflow_dispatch: # allows manual trigger from GitHub UI
   schedule:
     - cron: 0 4 * * 3,6 # run twice weekly
 


### PR DESCRIPTION
**Description**

Added manual trigger option for the workflow.

