### PR TITLE
chore: remove hardcoded GOMAXPROCS; print cpu info in startup-banner

### DIFF
--- a/dgraph/main.go
+++ b/dgraph/main.go
@@ -17,10 +17,6 @@ import (
 )
 
 func main() {
-	// Setting a higher number here allows more disk I/O calls to be scheduled, hence considerably
-	// improving throughput. The extra CPU overhead is almost negligible in comparison. The
-	// benchmark notes are located in badger-bench/randread.
-	runtime.GOMAXPROCS(128)
 
 	absDiff := func(a, b uint64) uint64 {
 		if a > b {

--- a/x/init.go
+++ b/x/init.go
@@ -50,6 +50,8 @@ Commit timestamp : %v
 Branch           : %v
 Go version       : %v
 jemalloc enabled : %v
+GOMAXPROCS       : %v
+Num CPUs         : %v
 
 For Dgraph official documentation, visit https://dgraph.io/docs.
 For discussions about Dgraph     , visit https://discuss.dgraph.io.
@@ -59,7 +61,7 @@ For discussions about Dgraph     , visit https://discuss.dgraph.io.
 
 `,
 		dgraphVersion, dgraphCodename, ExecutableChecksum(), lastCommitSHA, lastCommitTime, gitBranch,
-		runtime.Version(), jem, licenseInfo)
+		runtime.Version(), jem, runtime.GOMAXPROCS(0), runtime.NumCPU(), licenseInfo)
 }
 
 // PrintVersion prints version and other helpful information if --version.


### PR DESCRIPTION
**Description**

This PR removes the hardcoded `GOMAXPROCS(128)` from the shared `main.go`. Modern go runtimes (>1.25) on Linux and containers use cgroup to determine optimal CPU allocation.

This PR also introduces the printing of GOMAXPROCS and numcpus in the version banner.

**Checklist**

- [x] The PR title follows the
      [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax, leading
      with `fix:`, `feat:`, `chore:`, `ci:`, etc.
- [x] Code compiles correctly and linting (via trunk) passes locally
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable

