### PR TITLE
fix(test): resolve dgraph binary selection for macOS in dgraphtest and testutil

### DIFF
--- a/dgraph/cmd/dgraphimport/import_test.go
+++ b/dgraph/cmd/dgraphimport/import_test.go
@@ -10,9 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -326,11 +324,6 @@ func runImportTest(t *testing.T, tt testcase) {
 
 // setupBulkCluster creates and configures a cluster for bulk loading data
 func setupBulkCluster(t *testing.T, numAlphas int, encrypted bool) (*dgraphtest.LocalCluster, string) {
-	if runtime.GOOS != "linux" && os.Getenv("DGRAPH_BINARY") == "" {
-		fmt.Println("You can set the DGRAPH_BINARY environment variable to path of a native dgraph binary to run these tests")
-		t.Skip("Skipping test on non-Linux platforms due to dgraph binary dependency")
-	}
-
 	baseDir := t.TempDir()
 	bulkConf := dgraphtest.NewClusterConfig().
 		WithNumAlphas(numAlphas).

--- a/dgraph/cmd/live/load-json/load_test.go
+++ b/dgraph/cmd/live/load-json/load_test.go
@@ -9,7 +9,6 @@ package live
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -162,12 +161,6 @@ func TestLiveLoadJSONMultipleFiles(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	if runtime.GOOS != "linux" && os.Getenv("DGRAPH_BINARY") == "" {
-		fmt.Println("Skipping live load-json tests on non-Linux platforms due to dgraph binary dependency")
-		fmt.Println("You can set the DGRAPH_BINARY environment variable to path of a native dgraph binary to run these tests")
-		os.Exit(0)
-	}
-
 	_, thisFile, _, _ := runtime.Caller(0)
 	testDataDir = filepath.Dir(thisFile)
 

--- a/dgraph/cmd/live/load-uids/load_test.go
+++ b/dgraph/cmd/live/load-uids/load_test.go
@@ -351,12 +351,6 @@ func TestLiveLoadFileNameMultipleCorrect(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	if runtime.GOOS != "linux" && os.Getenv("DGRAPH_BINARY") == "" {
-		fmt.Println("Skipping live load-uids tests on non-Linux platforms due to dgraph binary dependency")
-		fmt.Println("You can set the DGRAPH_BINARY environment variable to path of a native dgraph binary to run these tests")
-		os.Exit(0)
-	}
-
 	alphaService = testutil.GetSockAddr()
 	alphaName = testutil.Instance
 

--- a/dgraph/cmd/version/version_test.go
+++ b/dgraph/cmd/version/version_test.go
@@ -6,10 +6,8 @@
 package version
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -19,11 +17,6 @@ import (
 
 // Test `dgraph version` with an empty config file.
 func TestMain(m *testing.M) {
-	if runtime.GOOS != "linux" && os.Getenv("DGRAPH_BINARY") == "" {
-		fmt.Println("Skipping version tests on non-Linux platforms due to dgraph binary dependency")
-		fmt.Println("You can set the DGRAPH_BINARY environment variable to path of a native dgraph binary to run these tests")
-		os.Exit(0)
-	}
 	m.Run()
 }
 

--- a/systest/1million/1million_test.go
+++ b/systest/1million/1million_test.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 
@@ -44,11 +43,6 @@ func Test1Million(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	if runtime.GOOS != "linux" && os.Getenv("DGRAPH_BINARY") == "" {
-		fmt.Println("Skipping 1million tests on non-Linux platforms due to dgraph binary dependency")
-		fmt.Println("You can set the DGRAPH_BINARY environment variable to path of a native dgraph binary to run these tests")
-		os.Exit(0)
-	}
 	noschemaFile := filepath.Join(testutil.TestDataDirectory, "1million-noindex.schema")
 	rdfFile := filepath.Join(testutil.TestDataDirectory, "1million.rdf.gz")
 	if err := testutil.MakeDirEmpty([]string{"out/0", "out/1", "out/2"}); err != nil {

--- a/systest/21million/bulk/run_test.go
+++ b/systest/21million/bulk/run_test.go
@@ -69,11 +69,6 @@ func BenchmarkQueries(b *testing.B) {
 }
 
 func TestMain(m *testing.M) {
-	if runtime.GOOS != "linux" && os.Getenv("DGRAPH_BINARY") == "" {
-		fmt.Println("Skipping 21million bulk tests on non-Linux platforms due to dgraph binary dependency")
-		fmt.Println("You can set the DGRAPH_BINARY environment variable to path of a native dgraph binary to run these tests")
-		os.Exit(0)
-	}
 	schemaFile := filepath.Join(testutil.TestDataDirectory, "21million.schema")
 	rdfFile := filepath.Join(testutil.TestDataDirectory, "21million.rdf.gz")
 	if err := testutil.MakeDirEmpty([]string{"out/0", "out/1", "out/2"}); err != nil {

--- a/systest/audit_encrypted/audit_test.go
+++ b/systest/audit_encrypted/audit_test.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -21,11 +20,6 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	if runtime.GOOS != "linux" && os.Getenv("DGRAPH_BINARY") == "" {
-		fmt.Println("Skipping audit_encrypted tests on non-Linux platforms due to dgraph binary dependency")
-		fmt.Println("You can set the DGRAPH_BINARY environment variable to path of a native dgraph binary to run these tests")
-		os.Exit(0)
-	}
 	m.Run()
 }
 

--- a/systest/cdc/cdc_test.go
+++ b/systest/cdc/cdc_test.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 
@@ -24,10 +23,6 @@ import (
 )
 
 func TestCDC(t *testing.T) {
-	if runtime.GOOS != "linux" && os.Getenv("DGRAPH_BINARY") == "" {
-		fmt.Println("You can set the DGRAPH_BINARY environment variable to path of a native dgraph binary to run these tests")
-		t.Skip("Skipping test on non-Linux platforms due to dgraph binary dependency")
-	}
 	defer os.RemoveAll("./cdc_logs/sink.log")
 	path := testutil.DgraphBinaryPath()
 	cmd := exec.Command(path, "increment", "--num", "10",

--- a/systest/export/export_test.go
+++ b/systest/export/export_test.go
@@ -12,12 +12,10 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -32,11 +30,6 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	if runtime.GOOS != "linux" && os.Getenv("DGRAPH_BINARY") == "" {
-		fmt.Println("Skipping export tests on non-Linux platforms due to dgraph binary dependency")
-		fmt.Println("You can set the DGRAPH_BINARY environment variable to path of a native dgraph binary to run these tests")
-		os.Exit(0)
-	}
 	m.Run()
 }
 

--- a/systest/integration2/bulk_loader_test.go
+++ b/systest/integration2/bulk_loader_test.go
@@ -8,10 +8,8 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 
@@ -65,10 +63,6 @@ const (
 )
 
 func TestBulkLoaderNoDqlSchema(t *testing.T) {
-	if runtime.GOOS != "linux" && os.Getenv("DGRAPH_BINARY") == "" {
-		fmt.Println("You can set the DGRAPH_BINARY environment variable to path of a native dgraph binary to run these tests")
-		t.Skip("Skipping test on non-Linux platforms due to dgraph binary dependency")
-	}
 	conf := dgraphtest.NewClusterConfig().WithNumAlphas(2).WithNumZeros(1).
 		WithACL(time.Hour).WithReplicas(1).WithBulkLoadOutDir(t.TempDir())
 	c, err := dgraphtest.NewLocalCluster(conf)

--- a/systest/ldbc/ldbc_test.go
+++ b/systest/ldbc/ldbc_test.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 
@@ -72,11 +71,6 @@ func TestQueries(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	if runtime.GOOS != "linux" && os.Getenv("DGRAPH_BINARY") == "" {
-		fmt.Println("Skipping LDBC tests on non-Linux platforms due to dgraph binary dependency")
-		fmt.Println("You can set the DGRAPH_BINARY environment variable to path of a native dgraph binary to run these tests")
-		os.Exit(0)
-	}
 	noschemaFile := filepath.Join(testutil.TestDataDirectory, "ldbcTypes.schema")
 	rdfFile := testutil.TestDataDirectory
 	if err := testutil.MakeDirEmpty([]string{"out/0"}); err != nil {

--- a/systest/loader/loader_test.go
+++ b/systest/loader/loader_test.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -24,11 +23,6 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	if runtime.GOOS != "linux" && os.Getenv("DGRAPH_BINARY") == "" {
-		fmt.Println("Skipping loader tests on non-Linux platforms due to dgraph binary dependency")
-		fmt.Println("You can set the DGRAPH_BINARY environment variable to path of a native dgraph binary to run these tests")
-		os.Exit(0)
-	}
 	m.Run()
 }
 

--- a/testutil/exec.go
+++ b/testutil/exec.go
@@ -116,11 +116,6 @@ func pipelineInternal(cmds [][]string, opts []CmdOpts) (string, error) {
 }
 
 func DgraphBinaryPath() string {
-	// Useful for OSX, as $GOPATH/bin/dgraph is set to the linux binary for docker
-	if dgraphBinary := os.Getenv("DGRAPH_BINARY"); dgraphBinary != "" {
-		return dgraphBinary
-	}
-
 	gopath := os.Getenv("GOPATH")
 
 	if gopath == "" {


### PR DESCRIPTION
On macOS, setupBinary() now copies both the Linux binary (for Docker containers) and the host-native binary (for local bulk/live loader commands) into tempBinDir. On Linux, a single binary serves both purposes. BulkLoad() and LiveLoad() use hostDgraphBinaryPath() to pick the correct one based on the platform. Removed macOS skip guards from 13 test files so all tests run on both platforms after make install.
