### PR TITLE
chore: suppress receipt of graphql request to logging level 2

### DIFF
--- a/graphql/admin/http.go
+++ b/graphql/admin/http.go
@@ -183,7 +183,7 @@ func (gs *graphqlSubscription) Subscribe(
 
 	audit.AuditWebSockets(ctx, req)
 	namespace := x.ExtractNamespaceHTTP(&http.Request{Header: reqHeader})
-	glog.V(2).Infof("namespace: %d. Got GraphQL request over HTTP.", ns)
+	glog.V(2).Infof("namespace: %d. Got GraphQL request over HTTP.", namespace)
 	// first load the schema, then do anything else
 	if err := LazyLoadSchema(namespace); err != nil {
 		return nil, err
@@ -225,7 +225,7 @@ func (gh *graphqlHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer span.End()
 
 	ns, _ := strconv.ParseUint(r.Header.Get("resolver"), 10, 64)
-	glog.Infof("namespace: %d. Got GraphQL request over HTTP.", ns)
+	glog.V(2).Infof("namespace: %d. Got GraphQL request over HTTP.", ns)
 	if err := gh.isValid(ns); err != nil {
 		glog.Errorf("namespace: %d. graphqlHandler not initialised: %s", ns, err)
 		WriteErrorResponse(w, r, errors.New(resolve.ErrInternal))


### PR DESCRIPTION
**Description**

This PR assigns the logging of GraphQL requests to log level 2.

**Checklist**

- [x] The PR title follows the
      [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax, leading
      with `fix:`, `feat:`, `chore:`, `ci:`, etc.
