### PR TITLE
fix(query): capture AttachNamespace return value for galaxy queries

### DIFF
--- a/query/mutation.go
+++ b/query/mutation.go
@@ -58,7 +58,7 @@ func ExpandEdges(ctx context.Context, m *pb.Mutations) ([]*pb.DirectedEdge, erro
 
 	// Reset the namespace to the original.
 	defer func(ns uint64) {
-		x.AttachNamespace(ctx, ns)
+		ctx = x.AttachNamespace(ctx, ns)
 	}(namespace)
 
 	for _, edge := range m.Edges {
@@ -68,7 +68,7 @@ func ExpandEdges(ctx context.Context, m *pb.Mutations) ([]*pb.DirectedEdge, erro
 			// to insert into. Now, attach the namespace in the context, so that further query
 			// proceeds as if made from the user of 'namespace'.
 			namespace = edge.GetNamespace()
-			x.AttachNamespace(ctx, namespace)
+			ctx = x.AttachNamespace(ctx, namespace)
 		}
 
 		var preds []string


### PR DESCRIPTION
## Summary
- `x.AttachNamespace` returns a new context but both call sites in `query/mutation.go` discarded the return value
- Galaxy (cross-namespace) queries would execute against the wrong namespace
- Fix captures the returned context at both call sites (lines 61 and 71)

## Test plan
- [x] `go build ./query/...` passes
- [ ] Integration test: verify galaxy queries execute against correct namespace