### PR TITLE
fix(posting): hold List lock in SetTs to prevent data race

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -896,6 +896,8 @@ func GetConflictKey(pk x.ParsedKey, key []byte, t *pb.DirectedEdge) uint64 {
 // SetTs allows us to set the transaction timestamp in mutation map. Should be used before the posting list is passed
 // on to the functions that would read the data.
 func (l *List) SetTs(readTs uint64) {
+	l.Lock()
+	defer l.Unlock()
 	l.mutationMap.setTs(readTs)
 }
 


### PR DESCRIPTION
## Summary
- `SetTs` modifies `MutableLayer.readTs` without holding the List lock
- Races with any concurrent reader or iterator on the same list
- Fix wraps the mutation in `Lock/Unlock`

## Test plan
- [x] `go build ./posting/...` passes
- [ ] `go test -race ./posting/...`