### PR TITLE
fix(worker): replace fatal x.Check with error handling on Raft apply path

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -886,7 +886,13 @@ func (n *node) processApplyCh() {
 
 			var proposal pb.Proposal
 			key := binary.BigEndian.Uint64(entry.Data[:8])
-			x.Check(proto.Unmarshal(entry.Data[8:], &proposal))
+			if err := proto.Unmarshal(entry.Data[8:], &proposal); err != nil {
+				glog.Errorf("Unable to unmarshal proposal at index=%d key=%d len=%d: %v",
+					entry.Index, key, len(entry.Data), err)
+				n.Proposals.Done(key, err)
+				n.Applied.Done(entry.Index)
+				continue
+			}
 			proposal.Index = entry.Index
 			updateStartTs(&proposal)
 


### PR DESCRIPTION
## Summary
- `x.Check(proto.Unmarshal(...))` on the Raft apply path calls `log.Fatalf` on error
- Since all replicas apply the same Raft log, a single corrupted entry crashes **every** replica — total unavailability
- Replace with proper error handling: log error, report to proposal caller, mark entry applied, continue

## Test plan
- [x] `go build ./worker/...` passes
- [ ] Verify corrupted proposals are handled gracefully without crashing