### PR TITLE
fix(raft): add bounded exponential backoff to retry loops

### DIFF
--- a/conn/node.go
+++ b/conn/node.go
@@ -276,9 +276,20 @@ func (n *Node) Snapshot() (raftpb.Snapshot, error) {
 
 // SaveToStorage saves the hard state, entries, and snapshot to persistent storage, in that order.
 func (n *Node) SaveToStorage(h *raftpb.HardState, es []raftpb.Entry, s *raftpb.Snapshot) {
-	for {
+	const maxRetries = 10
+	backoff := 100 * time.Millisecond
+	for attempt := 0; ; attempt++ {
 		if err := n.Store.Save(h, es, s); err != nil {
-			glog.Errorf("While trying to save Raft update: %v. Retrying...", err)
+			if attempt >= maxRetries {
+				glog.Fatalf("Raft WAL save failed after %d attempts, cannot continue safely: %v",
+					attempt, err)
+			}
+			glog.Errorf("While trying to save Raft update (attempt %d/%d): %v. Retrying...",
+				attempt+1, maxRetries, err)
+			time.Sleep(backoff)
+			if backoff < 5*time.Second {
+				backoff *= 2
+			}
 		} else {
 			return
 		}

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -774,13 +774,25 @@ func (n *node) applyCommitted(proposal *pb.Proposal, key uint64) error {
 
 		data, err := proto.Marshal(snap)
 		x.Check(err)
-		for {
-			// We should never let CreateSnapshot have an error.
-			err := n.Store.CreateSnapshot(snap.Index, n.ConfState(), data)
-			if err == nil {
-				break
+		{
+			const maxRetries = 10
+			backoff := 100 * time.Millisecond
+			for attempt := 0; ; attempt++ {
+				err := n.Store.CreateSnapshot(snap.Index, n.ConfState(), data)
+				if err == nil {
+					break
+				}
+				if attempt >= maxRetries {
+					glog.Errorf("CreateSnapshot failed after %d attempts: %v", attempt, err)
+					return err
+				}
+				glog.Warningf("Error while calling CreateSnapshot (attempt %d/%d): %v. Retrying...",
+					attempt+1, maxRetries, err)
+				time.Sleep(backoff)
+				if backoff < 5*time.Second {
+					backoff *= 2
+				}
 			}
-			glog.Warningf("Error while calling CreateSnapshot: %v. Retrying...", err)
 		}
 		// We can now discard all invalid versions of keys below this ts.
 		pstore.SetDiscardTs(snap.ReadTs)


### PR DESCRIPTION
## Summary
- `CreateSnapshot` and `SaveToStorage` retried forever with no backoff or timeout
- Persistent disk error caused hot CPU loop blocking all Raft proposal processing
- Added exponential backoff (100ms to 5s cap) with max 10 retries
- `CreateSnapshot` returns error after exhaustion; `SaveToStorage` uses `Fatalf` (WAL save is safety-critical)

## Test plan
- [x] `go build ./worker/... ./conn/...` passes
- [ ] Verify retry behavior under simulated disk errors