### PR TITLE
fix(query): correct always-true len >= 0 condition in cascade check

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -2293,7 +2293,7 @@ func ProcessGraph(ctx context.Context, sg, parent *SubGraph, rch chan error) {
 			if parent == nil {
 				// I'm root. We reach here if root had a function.
 
-				if len(sg.Params.Cascade.Fields) >= 0 {
+				if len(sg.Params.Cascade.Fields) > 0 {
 					// DesitUIDs for this level becomes the sourceUIDs for the next level. In updateUidMatrix with cascade,
 					// we end up modifying the first list from the uidMatrix which ends up modifying the srcUids of the next level.
 					// So to avoid that we make a copy.


### PR DESCRIPTION
## Summary
- `len(sg.Params.Cascade.Fields) >= 0` is always true, making the else branch dead code
- Every root query with a function performed an unnecessary UID copy
- Changed to `> 0` so copy only happens when cascade fields are present

## Test plan
- [x] `go build ./query/...` passes
- [ ] Verify cascade queries still work correctly
- [ ] Verify non-cascade root queries use zero-copy path