### PR TITLE
fix(query): correct error message to reference LimitQueryEdge

### DIFF
--- a/query/shortest.go
+++ b/query/shortest.go
@@ -231,7 +231,7 @@ func (sg *SubGraph) expandOut(ctx context.Context,
 		if numEdges > x.Config.LimitQueryEdge {
 			// If we've seen too many edges, stop the query.
 			rch <- errors.Errorf("Exceeded query edge limit = %v. Found %v edges.",
-				x.Config.LimitMutationsNquad, numEdges)
+				x.Config.LimitQueryEdge, numEdges)
 			return
 		}
 


### PR DESCRIPTION
## Summary
- Condition checks `LimitQueryEdge` but error message printed `LimitMutationsNquad`
- Users saw a misleading limit value in the error

## Test plan
- [x] `go build ./query/...` passes