### PR TITLE
fix(edgraph): cancel contexts immediately in retry loops instead of deferring

### DIFF
--- a/edgraph/access.go
+++ b/edgraph/access.go
@@ -435,25 +435,27 @@ func upsertGuardianAndGroot(closer *z.Closer, ns uint64) {
 	}
 	for closer.Ctx().Err() == nil {
 		ctx, cancel := context.WithTimeout(closer.Ctx(), time.Minute)
-		defer cancel()
 		ctx = x.AttachNamespace(ctx, ns)
 		if err := upsertGuardian(ctx); err != nil {
 			glog.Infof("Unable to upsert the guardian group. Error: %v", err)
+			cancel()
 			time.Sleep(100 * time.Millisecond)
 			continue
 		}
+		cancel()
 		break
 	}
 
 	for closer.Ctx().Err() == nil {
 		ctx, cancel := context.WithTimeout(closer.Ctx(), time.Minute)
-		defer cancel()
 		ctx = x.AttachNamespace(ctx, ns)
 		if err := upsertGroot(ctx, "password"); err != nil {
 			glog.Infof("Unable to upsert the groot account. Error: %v", err)
+			cancel()
 			time.Sleep(100 * time.Millisecond)
 			continue
 		}
+		cancel()
 		break
 	}
 }


### PR DESCRIPTION
## Summary
- `defer cancel()` inside retry loops only runs when the function returns, not per iteration
- Each retry accumulated an uncancelled context, leaking resources
- Call `cancel()` explicitly at the end of each iteration

## Test plan
- [x] `go build ./edgraph/...` passes