### PR TITLE
fix(edgraph): remove auth token from error message to prevent credential leak

### DIFF
--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -1997,7 +1997,7 @@ func hasPoormansAuth(ctx context.Context) error {
 		return errNoAuth
 	}
 	if tokens[0] != worker.Config.AuthToken {
-		return errors.Errorf("Provided auth token [%s] does not match. Permission denied.", tokens[0])
+		return errors.Errorf("Provided auth token does not match. Permission denied.")
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- Auth token was included verbatim in error message: `"Provided auth token [%s] does not match"`
- Leaked credentials to logs and potentially to clients
- Removed the token from the error message

## Test plan
- [x] `go build ./edgraph/...` passes