### PR TITLE
fix(worker): report snapshot success to Raft leader

### DIFF
--- a/worker/snapshot.go
+++ b/worker/snapshot.go
@@ -289,5 +289,6 @@ func (w *grpcWorker) StreamSnapshot(stream pb.Worker_StreamSnapshotServer) error
 		return err
 	}
 	glog.Infof("Stream snapshot: OK")
+	n.Raft().ReportSnapshot(snap.Context.GetId(), raft.SnapshotFinish)
 	return nil
 }


### PR DESCRIPTION
## Summary
- Only snapshot failure was reported via `ReportSnapshot`
- Without reporting success (`SnapshotFinish`), the leader may keep re-sending snapshots to an already caught-up follower

## Test plan
- [x] `go build ./worker/...` passes