### PR TITLE
fix(posting): use atomic operations for CachePL.lastUpdate

### DIFF
--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -591,7 +591,7 @@ func (ml *MemoryLayer) updateItemInCache(key string, delta []byte, startTs, comm
 		return
 	}
 
-	val.lastUpdate = commitTs
+	atomic.StoreUint64(&val.lastUpdate, commitTs)
 
 	if val.list != nil {
 		p := new(pb.PostingList)
@@ -756,7 +756,7 @@ func copyList(l *List) *List {
 }
 
 func (c *CachePL) Set(l *List, readTs uint64) {
-	if c.lastUpdate < readTs && (c.list == nil || c.list.maxTs < l.maxTs) {
+	if atomic.LoadUint64(&c.lastUpdate) < readTs && (c.list == nil || c.list.maxTs < l.maxTs) {
 		c.list = l
 	}
 }
@@ -806,7 +806,7 @@ func (ml *MemoryLayer) saveInCache(key []byte, l *List) {
 	defer l.RUnlock()
 	cacheItem := NewCachePL()
 	cacheItem.list = copyList(l)
-	cacheItem.lastUpdate = l.maxTs
+	atomic.StoreUint64(&cacheItem.lastUpdate, l.maxTs)
 	ml.cache.set(key, cacheItem)
 }
 


### PR DESCRIPTION
## Summary
- Two transactions committing to the same key race on writing `lastUpdate`
- All reads/writes to `lastUpdate` now use `atomic.StoreUint64`/`atomic.LoadUint64`

## Test plan
- [x] `go build ./posting/...` passes
- [ ] `go test -race ./posting/...`