### PR TITLE
docs(worker): clarify DROP ALL idempotency on Raft apply path

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -388,6 +388,11 @@ func (n *node) applyMutations(ctx context.Context, proposal *pb.Proposal) (rerr 
 	}
 
 	if proposal.Mutations.DropOp == pb.Mutations_ALL {
+		// Note: These operations are not atomic, but this runs on the Raft apply path.
+		// If the node crashes mid-operation, Raft will re-apply this entry on restart.
+		// Each sub-step (ResetTxns, DeleteAll, ResetCache, applySchema, updateType)
+		// is idempotent, so re-application is safe.
+
 		// Ensures nothing get written to disk due to commit proposals.
 		posting.Oracle().ResetTxns()
 		schema.State().DeleteAll()


### PR DESCRIPTION
## Summary
- The sequential operations in DROP ALL are not atomic, but run on the Raft apply path
- If the node crashes mid-operation, Raft re-applies the entry on restart
- Each sub-step (ResetTxns, DeleteAll, ResetCache, applySchema, updateType) is idempotent
- Added a comment to clarify this is safe by design

## Test plan
- [ ] Verify `go build ./worker/` succeeds