### PR TITLE
fix(conn): log warning when Raft messages are dropped on full channel

### DIFF
--- a/conn/node.go
+++ b/conn/node.go
@@ -388,6 +388,7 @@ func (n *Node) BatchAndSendMessages() {
 			select {
 			case s.msgCh <- data:
 			default:
+				glog.Warningf("Dropping Raft message to peer %#x, channel full", to)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- When the per-peer message channel (capacity 100) is full, messages were silently dropped
- This is especially problematic for `MsgProp` (follower→leader proposal forwarding) which is only sent once
- Added a warning log so operators can detect and investigate message drops

## Test plan
- [ ] Verify `go build ./conn/` succeeds
- [ ] Verify `go vet ./conn/` shows no new warnings