### PR TITLE
fix(worker): replace panic with glog.Fatalf in commitOrAbort disk write

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -989,9 +989,9 @@ func (n *node) commitOrAbort(pkey uint64, delta *pb.OracleDelta) error {
 			})
 
 		if err != nil {
-			glog.Errorf("Error while applying txn status to disk (%d -> %d): %v",
-				start, commit, err)
-			panic(err)
+			glog.Fatalf("Unrecoverable error applying txn status to disk (%d -> %d) "+
+				"after %d retries: %v. Exiting to prevent state divergence.",
+				start, commit, x.Config.MaxRetries, err)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- When `CommitToDisk` exhausts all retries, the code panicked with an unclear stack trace
- Replaced with `glog.Fatalf` which flushes logs before exiting, providing better diagnostics
- A fatal exit is correct here — continuing after failing to persist a committed Raft entry would risk state divergence

## Test plan
- [ ] Verify `go build ./worker/` succeeds
- [ ] Verify `go vet ./worker/` shows no new warnings