### PR TITLE
fix(ci): bump trivy to v0.69.3 to resolve 404 download failure

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -28,7 +28,7 @@ lint:
   enabled:
     - svgo@4.0.0
     - golangci-lint2@2.4.0
-    - trivy@0.65.0
+    - trivy@0.69.3
     - actionlint@1.7.7
     - checkov@3.2.467
     - dotenv-linter@3.3.0


### PR DESCRIPTION
## Summary

- Bumps Trivy from `0.65.0` to `0.69.3` in `.trunk/trunk.yaml`
- Trivy `v0.65.0` was never published — the version scheme jumped from `v0.26.0` to `v0.69.2`, causing a 404 when trunk tries to download the hermetic tool binary
- This fixes the "Trunk Code Quality / Check" CI failure seen on #9658 and all other PRs