### PR TITLE
fix(backup): prevent duplicate predicates in backup manifest for vector indexes

### DIFF
--- a/dgraphtest/local_cluster.go
+++ b/dgraphtest/local_cluster.go
@@ -1397,6 +1397,27 @@ func (c *LocalCluster) GetAlphaGrpcEndpoint(id int) (string, error) {
 
 // CopyExportToHost copies exported files from the container to a host directory.
 // It returns the paths to RDF/JSON files and schema files on the host.
+func (c *LocalCluster) ReadFileFromContainer(containerPath string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	defer cancel()
+
+	ts, _, err := c.dcli.CopyFromContainer(ctx, c.alphas[0].cid(), containerPath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error copying file from container [%v]", c.alphas[0].cname())
+	}
+	defer ts.Close()
+
+	tr := tar.NewReader(ts)
+	if _, err := tr.Next(); err != nil {
+		return nil, errors.Wrap(err, "error reading tar header")
+	}
+	data, err := io.ReadAll(tr)
+	if err != nil {
+		return nil, errors.Wrap(err, "error reading file contents from tar stream")
+	}
+	return data, nil
+}
+
 func (c *LocalCluster) CopyExportToHost(exportDir, hostDir string) (dataFiles, schemaFiles []string, err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
 	defer cancel()

--- a/systest/vector/backup_test.go
+++ b/systest/vector/backup_test.go
@@ -9,7 +9,9 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -20,6 +22,8 @@ import (
 	"github.com/dgraph-io/dgo/v250/protos/api"
 	"github.com/dgraph-io/dgraph/v25/dgraphapi"
 	"github.com/dgraph-io/dgraph/v25/dgraphtest"
+	"github.com/dgraph-io/dgraph/v25/tok/hnsw"
+	"github.com/dgraph-io/dgraph/v25/worker"
 	"github.com/dgraph-io/dgraph/v25/x"
 )
 
@@ -276,4 +280,354 @@ func TestVectorBackupRestoreReIndexing(t *testing.T) {
 	vectors = append(vectors, vectors2...)
 	rdfs = rdfs + rdfs2
 	testVectorQuery(t, gc, vectors, rdfs, pred, numVectors)
+}
+
+// readBackupManifest reads manifest.json from the backup directory inside the container.
+func readBackupManifest(t *testing.T, c *dgraphtest.LocalCluster) worker.MasterManifest {
+	t.Helper()
+	b, err := c.ReadFileFromContainer(filepath.Join(dgraphtest.DefaultBackupDir, "manifest.json"))
+	require.NoError(t, err)
+	var m worker.MasterManifest
+	require.NoError(t, json.Unmarshal(b, &m))
+	return m
+}
+
+// allUserPreds returns all non-internal predicates across all groups from a manifest entry.
+func allUserPreds(m *worker.Manifest) []string {
+	var preds []string
+	for _, ps := range m.Groups {
+		for _, p := range ps {
+			if !strings.HasPrefix(p, "dgraph.") {
+				preds = append(preds, p)
+			}
+		}
+	}
+	return preds
+}
+
+// userPredsPerGroup returns non-internal predicates grouped by their group ID.
+func userPredsPerGroup(m *worker.Manifest) map[uint32][]string {
+	result := make(map[uint32][]string)
+	for gid, ps := range m.Groups {
+		for _, p := range ps {
+			if !strings.HasPrefix(p, "dgraph.") {
+				result[gid] = append(result[gid], p)
+			}
+		}
+	}
+	return result
+}
+
+func assertVecSupportingPreds(t *testing.T, preds []string, vecPreds []string, ctx string) {
+	t.Helper()
+	for _, vecPred := range vecPreds {
+		require.Containsf(t, preds, vecPred, "%s: missing base predicate %q", ctx, vecPred)
+		require.Containsf(t, preds, vecPred+hnsw.VecEntry, "%s: missing %s for %q", ctx, hnsw.VecEntry, vecPred)
+		require.Containsf(t, preds, vecPred+hnsw.VecKeyword, "%s: missing %s for %q", ctx, hnsw.VecKeyword, vecPred)
+		require.Containsf(t, preds, vecPred+hnsw.VecDead, "%s: missing %s for %q", ctx, hnsw.VecDead, vecPred)
+	}
+}
+
+func assertNoDuplicates(t *testing.T, preds []string, ctx string) {
+	t.Helper()
+	seen := make(map[string]int)
+	for _, p := range preds {
+		seen[p]++
+	}
+	for p, count := range seen {
+		require.Equalf(t, 1, count, "%s: predicate %q appears %d times, expected 1", ctx, p, count)
+	}
+}
+
+func insertVectors(t *testing.T, gc *dgraphapi.GrpcClient, vecPreds []string, startIdx, endIdx int) {
+	t.Helper()
+	for _, p := range vecPreds {
+		rdfs, _ := dgraphapi.GenerateRandomVectors(startIdx, endIdx, 1, p)
+		mu := &api.Mutation{SetNquads: []byte(rdfs), CommitNow: true}
+		_, err := gc.Mutate(mu)
+		require.NoError(t, err)
+	}
+}
+
+// findGroupForPred returns the group ID that contains the given predicate.
+func findGroupForPred(m *worker.Manifest, pred string) (uint32, bool) {
+	for gid, ps := range m.Groups {
+		for _, p := range ps {
+			if p == pred {
+				return gid, true
+			}
+		}
+	}
+	return 0, false
+}
+
+func TestVectorBackupManifestPredicates(t *testing.T) {
+	conf := dgraphtest.NewClusterConfig().WithNumAlphas(1).WithNumZeros(1).WithReplicas(1).WithACL(time.Hour)
+	c, err := dgraphtest.NewLocalCluster(conf)
+	require.NoError(t, err)
+	defer func() { c.Cleanup(t.Failed()) }()
+	require.NoError(t, c.Start())
+
+	gc, cleanup, err := c.Client()
+	require.NoError(t, err)
+	defer cleanup()
+	require.NoError(t, gc.LoginIntoNamespace(context.Background(),
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.RootNamespace))
+
+	hc, err := c.HTTPClient()
+	require.NoError(t, err)
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.RootNamespace))
+
+	t.Run("single vector predicate", func(t *testing.T) {
+		require.NoError(t, gc.DropAll())
+
+		schema := `vec1: float32vector @index(hnsw(exponent: "5", metric: "euclidean")) .
+			name: string @index(exact) .`
+		require.NoError(t, gc.SetupSchema(schema))
+
+		insertVectors(t, gc, []string{"vec1"}, 0, 5)
+
+		require.NoError(t, hc.Backup(c, true, dgraphtest.DefaultBackupDir))
+
+		manifest := readBackupManifest(t, c)
+		require.Len(t, manifest.Manifests, 1)
+		preds := allUserPreds(manifest.Manifests[0])
+
+		fmt.Println("preds", preds)
+
+		require.Contains(t, preds, "0-name")
+		assertVecSupportingPreds(t, preds, []string{"0-vec1"}, "0-single-vec")
+		assertNoDuplicates(t, preds, "single-vec")
+	})
+
+	t.Run("multiple vector predicates in same group", func(t *testing.T) {
+		require.NoError(t, gc.DropAll())
+
+		schema := `vec_a: float32vector @index(hnsw(exponent: "5", metric: "euclidean")) .
+			vec_b: float32vector @index(hnsw(exponent: "5", metric: "euclidean")) .
+			vec_c: float32vector @index(hnsw(exponent: "5", metric: "cosine")) .
+			age: int .`
+		require.NoError(t, gc.SetupSchema(schema))
+
+		insertVectors(t, gc, []string{"vec_a", "vec_b", "vec_c"}, 0, 3)
+
+		require.NoError(t, hc.Backup(c, true, dgraphtest.DefaultBackupDir))
+
+		manifest := readBackupManifest(t, c)
+		require.GreaterOrEqual(t, len(manifest.Manifests), 1)
+		latest := manifest.Manifests[len(manifest.Manifests)-1]
+		preds := allUserPreds(latest)
+
+		require.Contains(t, preds, "0-age")
+		assertVecSupportingPreds(t, preds, []string{"0-vec_a", "0-vec_b", "0-vec_c"}, "multi-vec")
+		assertNoDuplicates(t, preds, "multi-vec")
+	})
+
+	t.Run("incremental backup preserves vector predicates", func(t *testing.T) {
+		require.NoError(t, gc.DropAll())
+
+		schema := `vec_x: float32vector @index(hnsw(exponent: "5", metric: "euclidean")) .
+			vec_y: float32vector @index(hnsw(exponent: "5", metric: "euclidean")) .`
+		require.NoError(t, gc.SetupSchema(schema))
+
+		insertVectors(t, gc, []string{"vec_x", "vec_y"}, 0, 3)
+		require.NoError(t, hc.Backup(c, true, dgraphtest.DefaultBackupDir))
+
+		insertVectors(t, gc, []string{"vec_x", "vec_y"}, 3, 6)
+		require.NoError(t, hc.Backup(c, false, dgraphtest.DefaultBackupDir))
+
+		manifest := readBackupManifest(t, c)
+		require.Len(t, manifest.Manifests, 4)
+
+		for i := 2; i < 4; i++ {
+			m := manifest.Manifests[i]
+			preds := allUserPreds(m)
+			ctx := fmt.Sprintf("manifest[%d]", i)
+			assertVecSupportingPreds(t, preds, []string{"0-vec_x", "0-vec_y"}, ctx)
+			assertNoDuplicates(t, preds, ctx)
+		}
+	})
+}
+
+func TestVectorBackupManifestMultiGroup(t *testing.T) {
+	conf := dgraphtest.NewClusterConfig().WithNumAlphas(2).WithNumZeros(1).WithReplicas(1).WithACL(time.Hour)
+	c, err := dgraphtest.NewLocalCluster(conf)
+	require.NoError(t, err)
+	defer func() { c.Cleanup(t.Failed()) }()
+	require.NoError(t, c.Start())
+
+	gc, cleanup, err := c.Client()
+	require.NoError(t, err)
+	defer cleanup()
+	require.NoError(t, gc.LoginIntoNamespace(context.Background(),
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.RootNamespace))
+
+	hc, err := c.HTTPClient()
+	require.NoError(t, err)
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.RootNamespace))
+
+	t.Run("vector predicates across multiple groups", func(t *testing.T) {
+		require.NoError(t, gc.DropAll())
+
+		schema := `vec_p: float32vector @index(hnsw(exponent: "5", metric: "euclidean")) .
+			vec_q: float32vector @index(hnsw(exponent: "5", metric: "euclidean")) .
+			vec_r: float32vector @index(hnsw(exponent: "5", metric: "cosine")) .
+			vec_s: float32vector @index(hnsw(exponent: "5", metric: "euclidean")) .
+			title: string @index(exact) .
+			score: int .
+			description: string .
+			rating: float .
+			active: bool @index(bool) .
+			tags: [string] @index(exact) .`
+		require.NoError(t, gc.SetupSchema(schema))
+
+		insertVectors(t, gc, []string{"vec_p", "vec_q", "vec_r", "vec_s"}, 0, 5)
+
+		require.NoError(t, hc.Backup(c, true, dgraphtest.DefaultBackupDir))
+
+		manifest := readBackupManifest(t, c)
+		latest := manifest.Manifests[len(manifest.Manifests)-1]
+
+		// Verify we have multiple groups.
+		require.GreaterOrEqual(t, len(latest.Groups), 2, "expected at least 2 groups with 2 alphas")
+
+		// For each vector predicate, verify its supporting predicates are in the SAME group.
+		for _, vecPred := range []string{"0-vec_p", "0-vec_q", "0-vec_r", "0-vec_s"} {
+			gid, found := findGroupForPred(latest, vecPred)
+			require.Truef(t, found, "base predicate %q not found in any group", vecPred)
+
+			groupPreds := latest.Groups[gid]
+			require.Containsf(t, groupPreds, vecPred+hnsw.VecEntry,
+				"group %d: missing %s for %q", gid, hnsw.VecEntry, vecPred)
+			require.Containsf(t, groupPreds, vecPred+hnsw.VecKeyword,
+				"group %d: missing %s for %q", gid, hnsw.VecKeyword, vecPred)
+			require.Containsf(t, groupPreds, vecPred+hnsw.VecDead,
+				"group %d: missing %s for %q", gid, hnsw.VecDead, vecPred)
+		}
+
+		// Verify no duplicates within each group independently.
+		for gid, preds := range userPredsPerGroup(latest) {
+			assertNoDuplicates(t, preds, fmt.Sprintf("group-%d", gid))
+		}
+
+		// Verify no duplicates across all groups combined.
+		assertNoDuplicates(t, allUserPreds(latest), "all-groups")
+	})
+
+	t.Run("incremental backup multi group", func(t *testing.T) {
+		require.NoError(t, gc.DropAll())
+
+		schema := `vec_m: float32vector @index(hnsw(exponent: "5", metric: "euclidean")) .
+			vec_n: float32vector @index(hnsw(exponent: "5", metric: "euclidean")) .
+			vec_o: float32vector @index(hnsw(exponent: "5", metric: "cosine")) .
+			label: string @index(exact) .
+			category: string .
+			weight: float .
+			enabled: bool @index(bool) .
+			status: string @index(exact) .`
+		require.NoError(t, gc.SetupSchema(schema))
+
+		insertVectors(t, gc, []string{"vec_m", "vec_n", "vec_o"}, 0, 3)
+		require.NoError(t, hc.Backup(c, true, dgraphtest.DefaultBackupDir))
+
+		insertVectors(t, gc, []string{"vec_m", "vec_n", "vec_o"}, 3, 6)
+		require.NoError(t, hc.Backup(c, false, dgraphtest.DefaultBackupDir))
+
+		manifest := readBackupManifest(t, c)
+		require.GreaterOrEqual(t, len(manifest.Manifests), 3)
+
+		// Verify the last 2 entries (full + incremental from this subtest).
+		for i := len(manifest.Manifests) - 2; i < len(manifest.Manifests); i++ {
+			m := manifest.Manifests[i]
+			require.GreaterOrEqual(t, len(m.Groups), 2,
+				"manifest[%d]: expected at least 2 groups", i)
+
+			for _, vecPred := range []string{"0-vec_m", "0-vec_n", "0-vec_o"} {
+				gid, found := findGroupForPred(m, vecPred)
+				require.Truef(t, found, "manifest[%d]: predicate %q not found", i, vecPred)
+
+				groupPreds := m.Groups[gid]
+				require.Containsf(t, groupPreds, vecPred+hnsw.VecEntry,
+					"manifest[%d] group %d: missing %s for %q", i, gid, hnsw.VecEntry, vecPred)
+				require.Containsf(t, groupPreds, vecPred+hnsw.VecKeyword,
+					"manifest[%d] group %d: missing %s for %q", i, gid, hnsw.VecKeyword, vecPred)
+				require.Containsf(t, groupPreds, vecPred+hnsw.VecDead,
+					"manifest[%d] group %d: missing %s for %q", i, gid, hnsw.VecDead, vecPred)
+			}
+
+			for gid, preds := range userPredsPerGroup(m) {
+				assertNoDuplicates(t, preds, fmt.Sprintf("manifest[%d]-group-%d", i, gid))
+			}
+			assertNoDuplicates(t, allUserPreds(m), fmt.Sprintf("manifest[%d]-all", i))
+		}
+	})
+}
+
+// TestVectorBackupAfterRestore verifies that taking a backup after a restore
+// does not produce duplicate supporting predicates in the manifest. The restore
+// code skips ForceTablet for supporting predicates so they remain absent from
+// Zero's membership state (consistent with normal operation). The backup code
+// discovers them via GetSchemaOverNetwork and adds them exactly once.
+func TestVectorBackupAfterRestore(t *testing.T) {
+	conf := dgraphtest.NewClusterConfig().WithNumAlphas(1).WithNumZeros(1).WithReplicas(1).WithACL(time.Hour)
+	c, err := dgraphtest.NewLocalCluster(conf)
+	require.NoError(t, err)
+	defer func() { c.Cleanup(t.Failed()) }()
+	require.NoError(t, c.Start())
+
+	gc, cleanup, err := c.Client()
+	require.NoError(t, err)
+	defer cleanup()
+	require.NoError(t, gc.LoginIntoNamespace(context.Background(),
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.RootNamespace))
+
+	hc, err := c.HTTPClient()
+	require.NoError(t, err)
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.RootNamespace))
+
+	schema := `vec_r1: float32vector @index(hnsw(exponent: "5", metric: "euclidean")) .
+		vec_r2: float32vector @index(hnsw(exponent: "5", metric: "cosine")) .
+		label: string @index(exact) .`
+	require.NoError(t, gc.SetupSchema(schema))
+
+	insertVectors(t, gc, []string{"vec_r1", "vec_r2"}, 0, 5)
+
+	// Take the initial backup.
+	require.NoError(t, hc.Backup(c, true, dgraphtest.DefaultBackupDir))
+
+	// Restore from the backup. Supporting predicates are NOT registered as
+	// tablets in Zero (ForceTablet is skipped for them), keeping the state
+	// consistent with normal operation.
+	require.NoError(t, hc.Restore(c, dgraphtest.DefaultBackupDir, "", 0, 0))
+	require.NoError(t, dgraphapi.WaitForRestore(c))
+
+	// Re-login after restore since sessions are invalidated.
+	gc, cleanup, err = c.Client()
+	require.NoError(t, err)
+	defer cleanup()
+	require.NoError(t, gc.LoginIntoNamespace(context.Background(),
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.RootNamespace))
+
+	hc, err = c.HTTPClient()
+	require.NoError(t, err)
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.RootNamespace))
+
+	// Insert more data and take another backup. Supporting predicates are
+	// not in Zero's membership state, so the backup code discovers them
+	// via GetSchemaOverNetwork and adds them exactly once.
+	insertVectors(t, gc, []string{"vec_r1", "vec_r2"}, 5, 10)
+	require.NoError(t, hc.Backup(c, true, dgraphtest.DefaultBackupDir))
+
+	manifest := readBackupManifest(t, c)
+	require.GreaterOrEqual(t, len(manifest.Manifests), 2)
+
+	latest := manifest.Manifests[len(manifest.Manifests)-1]
+	preds := allUserPreds(latest)
+
+	assertVecSupportingPreds(t, preds, []string{"0-vec_r1", "0-vec_r2"}, "post-restore-backup")
+	assertNoDuplicates(t, preds, "post-restore-backup")
 }

--- a/worker/backup.go
+++ b/worker/backup.go
@@ -287,10 +287,22 @@ func ProcessBackupRequest(ctx context.Context, req *pb.BackupRequest) error {
 
 	}
 
-	// see if any of the predicates are vector predicates and add the supporting
-	// vector predicates to the backup request.
+	// HNSW vector indexes create supporting predicates (entry, keyword, dead) that
+	// are not tracked as tablets in Zero's membership state. They exist only as data
+	// in the same Badger store as their base vector predicate. We need to discover
+	// them here and include them in the backup. Since the membership state only tells
+	// us which predicates belong to which group (not their type or index info), we
+	// call GetSchemaOverNetwork to fetch the schema from each group's Alpha and check
+	// which predicates are float32vector with HNSW indexes.
+	//
+	// Groups with no predicates must be skipped because GetSchemaOverNetwork treats
+	// an empty predicate list as "return all schemas from all groups", which would
+	// incorrectly associate supporting predicates from other groups with this group.
 	vecPredMap := make(map[uint32][]string)
 	for gid, preds := range predMap {
+		if len(preds) == 0 {
+			continue
+		}
 		schema, err := GetSchemaOverNetwork(ctx, &pb.SchemaRequest{Predicates: preds})
 		if err != nil {
 			return err
@@ -298,8 +310,8 @@ func ProcessBackupRequest(ctx context.Context, req *pb.BackupRequest) error {
 
 		for _, pred := range schema {
 			if pred.Type == "float32vector" && len(pred.IndexSpecs) != 0 {
-				vecPredMap[gid] = append(vecPredMap[gid], pred.Predicate+hnsw.VecEntry, pred.Predicate+hnsw.VecKeyword,
-					pred.Predicate+hnsw.VecDead)
+				vecPredMap[gid] = append(vecPredMap[gid], pred.Predicate+hnsw.VecEntry,
+					pred.Predicate+hnsw.VecKeyword, pred.Predicate+hnsw.VecDead)
 			}
 		}
 	}

--- a/worker/backup.go
+++ b/worker/backup.go
@@ -298,7 +298,7 @@ func ProcessBackupRequest(ctx context.Context, req *pb.BackupRequest) error {
 
 		for _, pred := range schema {
 			if pred.Type == "float32vector" && len(pred.IndexSpecs) != 0 {
-				vecPredMap[gid] = append(predMap[gid], pred.Predicate+hnsw.VecEntry, pred.Predicate+hnsw.VecKeyword,
+				vecPredMap[gid] = append(vecPredMap[gid], pred.Predicate+hnsw.VecEntry, pred.Predicate+hnsw.VecKeyword,
 					pred.Predicate+hnsw.VecDead)
 			}
 		}

--- a/worker/online_restore.go
+++ b/worker/online_restore.go
@@ -27,6 +27,7 @@ import (
 	"github.com/dgraph-io/dgraph/v25/posting"
 	"github.com/dgraph-io/dgraph/v25/protos/pb"
 	"github.com/dgraph-io/dgraph/v25/schema"
+	"github.com/dgraph-io/dgraph/v25/tok/hnsw"
 	"github.com/dgraph-io/dgraph/v25/x"
 )
 
@@ -304,6 +305,26 @@ func handleRestoreProposal(ctx context.Context, req *pb.RestoreRequest, pidx uin
 		restorePreds = buildPredsForDefaultNamespace(restorePreds, req.FromNamespace)
 	}
 	for _, pred := range restorePreds {
+		// HNSW vector indexes produce supporting predicates (__vector_entry,
+		// __vector_, __vector_dead) that are stored alongside the base vector
+		// predicate in the same Badger instance. During normal operation these
+		// are never registered as tablets in Zero — the HNSW code writes them
+		// directly via AddMutationWithLockHeld, and transaction validation in
+		// Zero's checkPreds strips the VecKeyword suffix to resolve the base
+		// predicate's group. Registering them here would create an inconsistent
+		// state that causes backup manifest duplication and may trigger futile
+		// rebalancing attempts.
+		//
+		// Skipping ForceTablet is safe because the restore mapper decides which
+		// data keys to restore based on the manifest's predicate set (predSet),
+		// not on Zero's tablet assignments. The supporting predicate data will
+		// still be restored to the correct Alpha's Badger store.
+		if strings.HasSuffix(pred, hnsw.VecEntry) ||
+			strings.HasSuffix(pred, hnsw.VecKeyword) ||
+			strings.HasSuffix(pred, hnsw.VecDead) {
+			continue
+		}
+
 		// Force the tablet to be moved to this group, even
 		// if it's currently being served by another group.
 		tablet, err := groups().ForceTablet(pred)


### PR DESCRIPTION
**Description**

Fixed a bug in ProcessBackupRequest where vecPredMap[gid] was being built using predMap[gid] as the append base instead of vecPredMap[gid]. This caused all base predicates in the group to be duplicated in the manifest every time a vector predicate was found, making manifest.json grow larger and larger with each backup.
With multiple vector predicates in the same group, each iteration also overwrote the previous result, so only the last vector predicate's supporting entries (__vector_entry, __vector_, __vector_dead) were kept  the rest were silently lost.
