### PR TITLE
fix(dql): whitespace sensitivity issues in conditional eval

### DIFF
--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -721,9 +721,21 @@ func validateCondValue(cond string) error {
 	}
 
 	lower := strings.ToLower(cond)
-	if !strings.HasPrefix(lower, "@if(") && !strings.HasPrefix(lower, "@filter(") {
+	if !strings.HasPrefix(lower, "@if") && !strings.HasPrefix(lower, "@filter") {
 		return errors.Errorf("invalid cond value: must start with @if( or @filter(")
 	}
+
+	// Strip the directive prefix and verify the remainder (after optional whitespace) starts with '('.
+	prefix := "@if"
+	if strings.HasPrefix(lower, "@filter") {
+		prefix = "@filter"
+	}
+	rest := strings.TrimSpace(cond[len(prefix):])
+	if len(rest) == 0 || rest[0] != '(' {
+		return errors.Errorf("invalid cond value: must start with @if( or @filter(")
+	}
+	// Rebuild cond without the space so the paren-balancing logic works on the normalized form.
+	cond = prefix + rest
 
 	openIdx := strings.Index(cond, "(")
 	if openIdx == -1 {
@@ -781,6 +793,7 @@ var valVarRegexp = regexp.MustCompile(`^val\([a-zA-Z_][a-zA-Z0-9_.]*\)$`)
 // validateValObjectId checks that an ObjectId starting with "val(" is a well-formed
 // val(variableName) reference and contains no injected DQL syntax.
 func validateValObjectId(objectId string) error {
+	objectId = strings.TrimSpace(objectId)
 	if !valVarRegexp.MatchString(objectId) {
 		return errors.Errorf("invalid val() reference in ObjectId: %q", objectId)
 	}
@@ -792,6 +805,7 @@ var langTagRegexp = regexp.MustCompile(`^[a-zA-Z]+(-[a-zA-Z0-9]+)*$`)
 
 // validateLangTag checks that a language tag contains only safe characters.
 func validateLangTag(lang string) error {
+	lang = strings.TrimSpace(lang)
 	if lang == "" {
 		return nil
 	}

--- a/edgraph/server_test.go
+++ b/edgraph/server_test.go
@@ -388,6 +388,11 @@ func TestValidateCondValue(t *testing.T) {
 		`@if(not(eq(len(v), 0)))`,
 		`@if(eq(name, "has (parens) inside"))`,
 		`@filter(eq(len(v), 0))`,
+		// Spaces between directive and opening paren should be allowed (issue #9687).
+		`@if (eq(len(v), 0))`,
+		`@if  (eq(len(v), 0))`,
+		`@filter (eq(len(v), 0))`,
+		` @if ( NOT eq(len(RoutesId), 0) ) `,
 	}
 	for _, c := range valid {
 		require.NoError(t, validateCondValue(c), "expected valid: %q", c)
@@ -430,6 +435,10 @@ func TestValidateValObjectId(t *testing.T) {
 		"val(queryVariable)",
 		"val(my_var_123)",
 		"val(Amt)",
+		// Leading/trailing whitespace should be tolerated.
+		" val(v)",
+		"val(v) ",
+		" val(v) ",
 	}
 	for _, v := range valid {
 		require.NoError(t, validateValObjectId(v), "expected valid: %q", v)
@@ -454,6 +463,10 @@ func TestValidateLangTag(t *testing.T) {
 		"fr",
 		"zh-Hans",
 		"en-US",
+		// Leading/trailing whitespace should be tolerated.
+		" en",
+		"en ",
+		" en ",
 	}
 	for _, v := range valid {
 		require.NoError(t, validateLangTag(v), "expected valid: %q", v)


### PR DESCRIPTION
Fixes #9687 

**Description**

**Three validators were introduced in commit `55e3b79` — all three had whitespace-sensitivity issues:**

| Validator | Issue | Fix |
|---|---|---|
| `validateCondValue` | `@if (...)` with space between directive and `(` was rejected | Normalize by stripping prefix, trimming, and verifying `(` |
| `validateValObjectId` | ` val(v) ` with leading/trailing whitespace rejected | Added `strings.TrimSpace()` before regex match |
| `validateLangTag` | `en ` with trailing whitespace rejected | Added `strings.TrimSpace()` before regex match |

The `validateValObjectId` and `validateLangTag` cases are in the `addQueryIfUnique` path (unique directive constraints), so less commonly hit than the `@if` case from #9687, but still reachable — especially via direct gRPC/protobuf clients that don't go through the RDF/JSON parsers (which happen to strip whitespace themselves). The RDF lexer for lang tags and the protobuf path for ObjectId both pass values through without trimming.


**Checklist**

- [x] The PR title follows the
      [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax, leading
      with `fix:`, `feat:`, `chore:`, `ci:`, etc.
- [x] Code compiles correctly and linting (via trunk) passes locally
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable